### PR TITLE
[tree] persistAs* Functions have other behaviour on already persisted items, PR for #422

### DIFF
--- a/lib/Gedmo/DoctrineExtensions.php
+++ b/lib/Gedmo/DoctrineExtensions.php
@@ -42,7 +42,7 @@ final class DoctrineExtensions
      * @param \Doctrine\ORM\Mapping\Driver\DriverChain $driverChain
      * @param \Doctrine\Common\Annotations\Reader $reader
      */
-    public static function registerMappingIntoDriverChainORM(DriverORM\DriverChain $driverChain, Reader $reader = null)
+    public static function registerMappingIntoDriverChainORM(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain $driverChain, Reader $reader = null)
     {
         self::registerAnnotations();
         if (!$reader) {
@@ -63,7 +63,7 @@ final class DoctrineExtensions
      * @param \Doctrine\ORM\Mapping\Driver\DriverChain $chain
      * @param \Doctrine\Common\Annotations\Reader $reader
      */
-    public static function registerAbstractMappingIntoDriverChainORM(DriverORM\DriverChain $driverChain, Reader $reader = null)
+    public static function registerAbstractMappingIntoDriverChainORM(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain $driverChain, Reader $reader = null)
     {
         self::registerAnnotations();
         if (!$reader) {

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -166,6 +166,33 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $this->assertEquals(11, $fruits->getRight());
     }
 
+    public function testTreePositionUpdates()
+    {
+        $repo = $this->em->getRepository(self::ROOT_CATEGORY);
+        
+        $this->populate();
+        $tree = $this->debugTree($repo);
+        $this->em->clear();
+        
+        foreach (array('food','fruits','vegitables','meat','oranges','citrons','milk') as $node) {
+            $$node = $repo->findOneByTitle(ucfirst($node));
+        }
+        
+        $repo
+            ->persistAsFirstChild($food)
+            ->persistAsFirstChildOf($fruits, $food)
+            ->persistAsFirstChildOf($vegitables, $food)
+            ->persistAsLastChildOf($milk, $food)
+            ->persistAsLastChildOf($meat, $food)
+            ->persistAsFirstChildOf($oranges, $fruits)
+            ->persistAsFirstChildOf($citrons, $fruits);
+        
+        $this->em->flush();
+        
+        $this->assertEquals($tree, $this->debugTree($repo));
+    }
+
+
     public function testTreeChildPositionMove()
     {
         $this->populate();
@@ -268,7 +295,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $count = $this->em->createQuery($dql)->getSingleScalarResult();
         $this->assertEquals(6, $count);
     }
-
+    
     public function testRootTreePositionedInserts()
     {
         $repo = $this->em->getRepository(self::ROOT_CATEGORY);
@@ -432,6 +459,24 @@ class NestedTreePositionTest extends BaseTestCaseORM
             ->persistAsFirstChildOf($citrons, $fruits);
 
         $this->em->flush();
+    }
+
+    protected function debugTree($repository) {
+        return "\n".$repository->childrenHierarchy(
+            null,
+            FALSE,
+            array(
+                'decorate'=>true,
+                'rootOpen' => '',
+                'rootClose' => '',
+                'childOpen' => '',
+                'childClose' => '',
+                'nodeDecorator'=>function ($node) {
+                    $node = (object) $node;
+                    return str_repeat(' ', $node->level).$node->title."\n";
+                }
+                )
+        )."\n";
     }
 
     protected function getUsedEntityFixtures()


### PR DESCRIPTION
Attached is a test for the issue

the test fails with:

```
There was 1 failure:

1) Gedmo\Tree\NestedTreePositionTest::testFullTreePositionUpdates
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '
+ Vegitables
+ Meat
 Food
- Vegitables
+ Milk
  Fruits
   Citrons
   Oranges
- Milk
- Meat

 '

D:\www\DoctrineExtensions\tests\Gedmo\Tree\NestedTreePositionTest.php:194
```

In my humble oppinon this should produce / update the same tree as before, shouldn't it?

If we don't do a clear() after popuplate we get an exception:

```
1) Gedmo\Tree\NestedTreePositionTest::testFullTreePositionUpdates
Gedmo\Exception\UnexpectedValueException: Cannot set child as parent to node: 5

D:\www\DoctrineExtensions\lib\Gedmo\Tree\Strategy\ORM\Nested.php:325
D:\www\DoctrineExtensions\lib\Gedmo\Tree\Strategy\ORM\Nested.php:166
D:\www\DoctrineExtensions\lib\Gedmo\Tree\TreeListener.php:123
D:\www\DoctrineExtensions\vendor\doctrine-common\lib\Doctrine\Common\EventManager.php:62
D:\www\DoctrineExtensions\vendor\doctrine-orm\lib\Doctrine\ORM\UnitOfWork.php:296
D:\www\DoctrineExtensions\vendor\doctrine-orm\lib\Doctrine\ORM\EntityManager.php:355
D:\www\DoctrineExtensions\tests\Gedmo\Tree\NestedTreePositionTest.php:189
C:\Program Files (x86)\PHP\phpunit:46
```

issue #422
