### PR TITLE
updateNode (update node["parent"])

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -302,6 +302,13 @@ class Nested implements Strategy
                         throw new UnexpectedValueException("Cannot persist sibling for a root node, tree operation is not possible");
                     }
                     $wrapped->setPropertyValue($config['parent'], $newParent);
+
+                    $dql = "UPDATE {$meta->name} node";
+                    $dql .= " SET node.{$config['parent']} = {$newParent->getId()}";
+                    $dql .= " WHERE node.{$identifierField} = {$nodeId}";
+                    $q = $em->createQuery($dql);
+                    $q->getSingleScalarResult();
+
                     $em->getUnitOfWork()->recomputeSingleEntityChangeSet($meta, $node);
                     $start = $parentRight + 1;
                     break;


### PR DESCRIPTION
Hello.

I need to update whole tree in db (from admin area build on SonataAdminBundle)
I have an array of arrays (hierarchy).

I use this code in Repository which extends NestedTreeRepository

```
public function updateChilds($childrens,$parent)
{
    foreach($childrens as $position=>$child)
    {
        $node = $this->find($child->id);
        $meta = $this->getClassMetadata();

        if(($parent != null) && ($node->getParent()->getId() != $parent->getId())){
            if($position > 0){
                $siblingNode = $this->find($childrens[$position-1]->id);
                $this->listener->getStrategy($this->_em, $meta->name)->updateNode($this->_em,$node,$siblingNode,Nested::NEXT_SIBLING);
            }else{
                $node->setParent($parent);
                $this->listener->getStrategy($this->_em, $meta->name)->updateNode($this->_em,$node,$parent,Nested::LAST_CHILD);
            }
        }else{
            $this->listener->getStrategy($this->_em, $meta->name)->updateNode($this->_em,$node,$parent,Nested::LAST_CHILD);
        }
        if(isset($child->children)){
            $this->updateChilds($child->children,$node);
        }
    }
    return true;
}
```

But current library do not change parent of the node when updateNode is called. Also, I cant do it from my repository code. 

I have added patch for this issue, not sure if its correct approach though.

Could you please offer another solution for this task or merge this PR.

Thanks
