### PR TITLE
[Sluggable] History of changed slugs

### DIFF
--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -876,7 +876,7 @@ $article->setTitle('the updated title');
 $em->persist($article);
 $em->flush();
 
-$repository = $em->getRepository('Sluggable\\Fixture\\ArticleWithHistory');
+$repository = $em->getRepository('Sluggable\\Fixture\\History');
 // Use findBy* where * is slug property by which you want to search
 $article = $repository->findBySlug('the-title-my-code');
 

--- a/lib/Gedmo/Mapping/Annotation/All.php
+++ b/lib/Gedmo/Mapping/Annotation/All.php
@@ -14,6 +14,7 @@ include __DIR__.'/Loggable.php';
 include __DIR__.'/Slug.php';
 include __DIR__.'/SlugHandler.php';
 include __DIR__.'/SlugHandlerOption.php';
+include __DIR__.'/SlugHistory.php';
 include __DIR__.'/SoftDeleteable.php';
 include __DIR__.'/SortableGroup.php';
 include __DIR__.'/SortablePosition.php';

--- a/lib/Gedmo/Mapping/Annotation/SlugHistory.php
+++ b/lib/Gedmo/Mapping/Annotation/SlugHistory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gedmo\Mapping\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Slug history annotation for Sluggable behavioral extension
+ *
+ * @Annotation
+ * @Target("CLASS")
+ *
+ * @author Martin Jantosovic <jantosovic.martin@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+final class SlugHistory extends Annotation
+{
+	/** @var string */
+	public $slugEntryClass;
+}

--- a/lib/Gedmo/Sluggable/Entity/MappedSuperclass/AbstractSlugEntry.php
+++ b/lib/Gedmo/Sluggable/Entity/MappedSuperclass/AbstractSlugEntry.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Gedmo\Sluggable\Entity\MappedSuperclass;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Gedmo\Sluggable\Entity\AbstractSlugEntry
+ *
+ * @ORM\MappedSuperclass
+ *
+ * @author Martin Jantosovic <jantosovic.martin@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+abstract class AbstractSlugEntry {
+
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    protected $id;
+
+    /**
+     * Slug field name
+     *
+     * @ORM\Column(length=255, name="slug_field")
+     */
+    protected $slugField;
+
+    /**
+     * Slug field value
+     *
+     * @ORM\Column(length=255, name="slug_value")
+     */
+    protected $slugValue;
+
+    /**
+     * @var string $objectId
+     *
+     * @ORM\Column(name="object_id", length=32, nullable=true)
+     */
+    protected $objectId;
+
+    /**
+     * @var string $objectClass
+     *
+     * @ORM\Column(name="object_class", type="string", length=255)
+     */
+    protected $objectClass;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected $created;
+
+    /**
+     * Get object class
+     *
+     * @return string
+     */
+    public function getObjectClass() {
+        return $this->objectClass;
+    }
+
+    /**
+     * Set object class
+     *
+     * @param string $objectClass
+     */
+    public function setObjectClass($objectClass) {
+        $this->objectClass = $objectClass;
+    }
+
+    /**
+     * Get object id
+     *
+     * @return string
+     */
+    public function getObjectId() {
+        return $this->objectId;
+    }
+
+    /**
+     * Set object id
+     *
+     * @param string $objectId
+     */
+    public function setObjectId($objectId) {
+        $this->objectId = $objectId;
+    }
+
+    /**
+     * Get created
+     *
+     * @return datetime
+     */
+    public function getCreated() {
+        return $this->created;
+    }
+
+    /**
+     * Set created
+     */
+    public function setCreated() {
+        $this->created = new \DateTime();
+    }
+
+    /**
+     * Get slug field
+     *
+     * @return string
+     */
+    public function getSlugField() {
+        return $this->slugField;
+    }
+
+    /**
+     * Set slug field
+     *
+     * @param string $slug
+     */
+    public function setSlugField($slugField) {
+        $this->slugField = $slugField;
+    }
+
+    /**
+     * Get slug value
+     *
+     * @return string
+     */
+    public function getSlugValue() {
+        return $this->slugValue;
+    }
+
+    /**
+     * Set slug value
+     *
+     * @param string $slug
+     */
+    public function setSlugValue($slugValue) {
+        $this->slugValue = $slugValue;
+    }
+
+}

--- a/lib/Gedmo/Sluggable/Entity/Repository/SlugEntryRepository.php
+++ b/lib/Gedmo/Sluggable/Entity/Repository/SlugEntryRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Gedmo\Sluggable\Entity\Repository;
+
+use Gedmo\Tool\Wrapper\EntityWrapper,
+    Doctrine\ORM\EntityRepository,
+    Gedmo\Sluggable\SluggableListener;
+
+/**
+ * The SlugEntryRepository has some useful functions
+ * to interact with slug history.
+ *
+ * @author Martin Jantosovic <jantosovic.martin@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class SlugEntryRepository extends EntityRepository
+{
+    /**
+     * Currently used loggable listener
+     *
+     * @var SluggableListener
+     */
+    private $listener;
+
+    /**
+     * Allow findOneBy*, where * is slugField
+     */
+    public function __call($method, $arguments)
+    {
+        switch (true) {
+            case (0 === strpos($method, 'findOneBy')):
+                $by = substr($method, 9);
+                $method = 'findOneBy';
+                break;
+
+            default:
+                throw new \BadMethodCallException(
+                    "Undefined method '$method'. The method name must start with ".
+                    "either findBy or findOneBy!"
+                );
+        }
+
+        if (empty($arguments)) {
+            throw ORMException::findByRequiresParameter($method . $by);
+        }
+
+        $slugField = lcfirst(\Doctrine\Common\Util\Inflector::classify($by));
+        $slugValue = $arguments[0];
+        if (count($arguments) > 1) {
+            $slugEntry = $this->$method(array(
+                'slugField' => $slugField,
+                'slugValue' => $slugValue,
+                'objectClass' => $arguments[1]
+            ));
+        } else {
+            $slugEntry = $this->$method(array(
+                'slugField' => $slugField,
+                'slugValue' => $slugValue
+            ));
+        }
+
+        if ($slugEntry) {
+            return $this->getEntityManager()->getRepository($slugEntry->getObjectClass())
+                ->find($slugEntry->getObjectId());
+        } else
+            return NULL;
+    }
+
+    /**
+     * Get the currently used SluggableListener
+     *
+     * @throws \Gedmo\Exception\RuntimeException - if listener is not found
+     * @return SluggableListener
+     */
+    private function getSluggableListener()
+    {
+        if (is_null($this->listener)) {
+            foreach ($this->_em->getEventManager()->getListeners() as $event => $listeners) {
+                foreach ($listeners as $hash => $listener) {
+                    if ($listener instanceof SluggableListener) {
+                        $this->listener = $listener;
+                        break;
+                    }
+                }
+                if ($this->listener) {
+                    break;
+                }
+            }
+
+            if (is_null($this->listener)) {
+                throw new \Gedmo\Exception\RuntimeException('The sluggable listener could not be found');
+            }
+        }
+        return $this->listener;
+    }
+}

--- a/lib/Gedmo/Sluggable/Entity/SlugEntry.php
+++ b/lib/Gedmo/Sluggable/Entity/SlugEntry.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gedmo\Sluggable\Entity;
+
+use Doctrine\ORM\Mapping\Table,
+    Doctrine\ORM\Mapping\Index,
+    Doctrine\ORM\Mapping\Entity;
+
+/**
+ * Gedmo\Sluggable\Entity\SlugEntry
+ *
+ * @Table(
+ *     name="ext_slug_entries",
+ *  indexes={
+ *      @index(name="slug_class_lookup_idx", columns={"slug", "object_class"}),
+ *      @index(name="slug_date_lookup_idx", columns={"created"})
+ *  }
+ * )
+ * @Entity(repositoryClass="Gedmo\Sluggable\Entity\Repository\SlugEntryRepository")
+ *
+ * @author Martin Jantosovic <jantosovic.martin@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class SlugEntry extends MappedSuperclass\AbstractSlugEntry {
+    /**
+     * All required columns are mapped through inherited superclass
+     */
+}

--- a/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
+++ b/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
@@ -115,13 +115,22 @@ class TreeSlugHandler implements SlugHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug)
+    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug, $history = FALSE)
     {
         if (!$this->isInsert) {
             $wrapped = AbstractWrapper::wrap($object, $this->om);
             $meta = $wrapped->getMetadata();
             $target = $wrapped->getPropertyValue($config['slug']);
             $config['pathSeparator'] = $this->usedPathSeparator;
+            // Store old slug to history
+            if ($history) {
+                $relatives = $ea->getRelative($config, $target.$config['pathSeparator']);
+                foreach ($relatives as $relative) {
+                    $w = AbstractWrapper::wrap($relative, $this->om);
+                    $s = $w->getPropertyValue($config['slug']);
+                    $this->sluggable->createSlugEntry($config['slug'], $s, $relative, $ea);
+                }
+            }
             $ea->replaceRelative($object, $config, $target.$config['pathSeparator'], $slug);
             $uow = $this->om->getUnitOfWork();
             // update in memory objects

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -36,6 +36,11 @@ class Annotation extends AbstractAnnotationDriver
     const HANDLER_OPTION ='Gedmo\\Mapping\\Annotation\\SlugHandlerOption';
 
     /**
+     * Slug history annotation
+     */
+    const SLUG_HISTORY = 'Gedmo\\Mapping\\Annotation\\SlugHistory';
+
+    /**
      * List of types which are valid for slug and sluggable fields
      *
      * @var array
@@ -79,8 +84,8 @@ class Annotation extends AbstractAnnotationDriver
                         if (!strlen($handler->class)) {
                             throw new InvalidMappingException("SlugHandler class: {$handler->class} should be a valid class name in entity - {$meta->name}");
                         }
-                        $class = $handler->class;
-                        $handlers[$class] = array();
+                        $clazz = $handler->class;
+                        $handlers[$clazz] = array();
                         foreach ((array)$handler->options as $option) {
                             if (!$option instanceof SlugHandlerOption) {
                                 throw new InvalidMappingException("SlugHandlerOption: {$option} should be instance of SlugHandlerOption annotation in entity - {$meta->name}");
@@ -88,9 +93,9 @@ class Annotation extends AbstractAnnotationDriver
                             if (!strlen($option->name)) {
                                 throw new InvalidMappingException("SlugHandlerOption name: {$option->name} should be valid name in entity - {$meta->name}");
                             }
-                            $handlers[$class][$option->name] = $option->value;
+                            $handlers[$clazz][$option->name] = $option->value;
                         }
-                        $class::validate($handlers[$class], $meta);
+                        $clazz::validate($handlers[$clazz], $meta);
                     }
                 }
                 // process slug fields
@@ -135,5 +140,23 @@ class Annotation extends AbstractAnnotationDriver
                 );
             }
         }
+
+        // class annotations
+        if ($config && ($annot = $this->reader->getClassAnnotation($class, self::SLUG_HISTORY))) {
+            $config['slugHistory'] = TRUE;
+            if ($annot->slugEntryClass) {
+                if (!class_exists($annot->slugEntryClass)) {
+                    throw new InvalidMappingException("SlugEntry class: {$annot->slugEntryClass} does not exist.");
+                }
+                $config['slugEntryClass'] = $annot->slugEntryClass;
+            }
+        }
+
+        if (!$meta->isMappedSuperclass && isset($config['slugHistory']) && $config['slugHistory']) {
+            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+                throw new InvalidMappingException("Slug history does not support composite identifiers in class - {$meta->name}");
+            }
+        }
+
     }
 }

--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -19,6 +19,14 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
     /**
      * {@inheritDoc}
      */
+    public function getDefaultSlugEntryClass()
+    {
+        return 'Gedmo\\Sluggable\\Entity\\SlugEntry';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getSimilarSlugs($object, $meta, array $config, $slug)
     {
         $dm = $this->getObjectManager();

--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -19,6 +19,14 @@ final class ORM extends BaseAdapterORM implements SluggableAdapter
     /**
      * {@inheritDoc}
      */
+    public function getDefaultSlugEntryClass()
+    {
+        return 'Gedmo\\Sluggable\\Entity\\SlugEntry';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getSimilarSlugs($object, $meta, array $config, $slug)
     {
         $em = $this->getObjectManager();

--- a/lib/Gedmo/Sluggable/Mapping/Event/SluggableAdapter.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/SluggableAdapter.php
@@ -14,6 +14,13 @@ use Gedmo\Mapping\Event\AdapterInterface;
 interface SluggableAdapter extends AdapterInterface
 {
     /**
+     * Get default SlugEntry class used to store the slugs
+     *
+     * @return string
+     */
+    function getDefaultSlugEntryClass();
+
+    /**
      * Loads the similar slugs
      *
      * @param object $object

--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Doctrine\Common\Persistence\ObjectManager;
+use Gedmo\Tool\Wrapper\AbstractWrapper;
 
 /**
  * The SluggableListener handles the generation of slugs
@@ -20,7 +21,6 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 class SluggableListener extends MappedEventSubscriber
 {
-
     /**
      * The power exponent to jump
      * the slug unique number by tens.
@@ -219,7 +219,24 @@ class SluggableListener extends MappedEventSubscriber
             $meta = $om->getClassMetadata(get_class($object));
             if (($config = $this->getConfiguration($om, $meta->name)) && !$uow->isScheduledForInsert($object)) {
                 $this->generateSlug($ea, $object);
+                // Store slugs history if slug field is changed
+                foreach ($config['slugs'] as $slugField => $options) {
+                    $changeSet = $ea->getObjectChangeSet($uow, $object);
+                    if (isset($config['slugHistory']) && $config['slugHistory']
+						&& isset($changeSet[$slugField]) && $changeSet[$slugField][0])
+                        $this->createSlugEntry($slugField, $changeSet[$slugField][0], $object, $ea);
+                }
                 $this->persisted[$ea->getRootObjectClass($meta)][] = $object;
+            }
+        }
+
+        foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
+            $meta = $om->getClassMetadata(get_class($object));
+            if (($config = $this->getConfiguration($om, $meta->name))
+				&& isset($config['slugHistory']) && $config['slugHistory']) {
+                // Delete all slug history entries
+                // if the entity is deleted
+                $this->deleteSlugEntries($object, $ea);
             }
         }
 
@@ -368,7 +385,7 @@ class SluggableListener extends MappedEventSubscriber
                 // notify slug handlers --> onSlugCompletion
                 if ($hasHandlers) {
                     foreach ($options['handlers'] as $class => $handlerOptions) {
-                        $this->getHandler($class)->onSlugCompletion($ea, $options, $object, $slug);
+                        $this->getHandler($class)->onSlugCompletion($ea, $options, $object, $slug, isset($config['slugHistory']) && $config['slugHistory']);
                     }
                 }
                 // set the final slug
@@ -512,6 +529,90 @@ class SluggableListener extends MappedEventSubscriber
         }
 
         throw new \Gedmo\Exception\InvalidArgumentException("ObjectManager does not support filters");
+    }
+
+    /**
+     * Create a new Slug history instance
+     *
+     * @param object $object
+     * @param LoggableAdapter $ea
+     * @return void
+     */
+    public function createSlugEntry($field, $slug, $object, SluggableAdapter $ea)
+    {
+        $om = $ea->getObjectManager();
+        $wrapped = AbstractWrapper::wrap($object, $om);
+        $meta = $wrapped->getMetadata();
+        $uow = $om->getUnitOfWork();
+
+        $slugEntryClass = $this->getSlugEntryClass($ea, $meta->name);
+        $slugEntryMeta = $om->getClassMetadata($slugEntryClass);
+
+        $repository = $om->getRepository($slugEntryClass);
+        $slugEntry = $repository->findOneBy(array(
+            'slugField' => $field,
+            'slugValue' => $slug,
+            'objectClass' => $meta->name
+        ));
+
+        if ($slugEntry) { // Redefine slug
+            $slugEntry->setObjectId($wrapped->getIdentifier());
+            $slugEntry->setCreated();
+        } else { // Slug is not in the history
+            $slugEntry = $slugEntryMeta->newInstance();
+
+            $slugEntry->setObjectClass($meta->name);
+            $slugEntry->setCreated();
+            $slugEntry->setObjectId($wrapped->getIdentifier());
+            $slugEntry->setSlugField($field);
+            $slugEntry->setSlugValue($slug);
+        }
+
+        $om->persist($slugEntry);
+        $uow->computeChangeSet($slugEntryMeta, $slugEntry);
+    }
+
+    /**
+     * Delete a Slug history instance
+     *
+     * @param object $object
+     * @param LoggableAdapter $ea
+     * @return void
+     */
+    public function deleteSlugEntries($object, SluggableAdapter $ea)
+    {
+        $om = $ea->getObjectManager();
+        $wrapped = AbstractWrapper::wrap($object, $om);
+        $meta = $wrapped->getMetadata();
+        if ($config = $this->getConfiguration($om, $meta->name)) {
+
+            $slugEntryClass = $this->getSlugEntryClass($ea, $meta->name);
+            $slugEntryMeta = $om->getClassMetadata($slugEntryClass);
+
+            $repository = $om->getRepository($slugEntryClass);
+            $slugEntries = $repository->findBy(array(
+                'objectClass' => $meta->name,
+                'objectId' => $wrapped->getIdentifier()
+            ));
+
+            foreach ($slugEntries as $slugEntry) {
+                $om->remove($slugEntry);
+            }
+        }
+    }
+
+    /**
+     * Get the SlugEntry class
+     *
+     * @param LoggableAdapter $ea
+     * @param string $class
+     * @return string
+     */
+    protected function getSlugEntryClass(SluggableAdapter $ea, $class)
+    {
+        return isset(self::$configurations[$this->name][$class]['slugEntryClass']) ?
+            self::$configurations[$this->name][$class]['slugEntryClass'] :
+            $ea->getDefaultSlugEntryClass();
     }
 
 }

--- a/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
+++ b/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
@@ -319,6 +319,10 @@ abstract class AbstractMaterializedPath implements Strategy
 
         if (isset($config['level'])) {
             $level = substr_count($path, $config['path_separator']);
+            if ($config['path_starts_with_separator'])
+                $level--;
+            if ($config['path_ends_with_separator'])
+                $level--;
             $levelProp = $meta->getReflectionProperty($config['level']);
             $levelProp->setAccessible(true);
             $levelProp->setValue($node, $level);

--- a/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
+++ b/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
@@ -319,10 +319,12 @@ abstract class AbstractMaterializedPath implements Strategy
 
         if (isset($config['level'])) {
             $level = substr_count($path, $config['path_separator']);
-            if ($config['path_starts_with_separator'])
+            if ($config['path_starts_with_separator']) {
                 $level--;
-            if ($config['path_ends_with_separator'])
+            }
+            if ($config['path_ends_with_separator']) {
                 $level--;
+            }
             $levelProp = $meta->getReflectionProperty($config['level']);
             $levelProp->setAccessible(true);
             $levelProp->setValue($node, $level);

--- a/tests/Gedmo/Sluggable/Fixture/ArticleWithHistory.php
+++ b/tests/Gedmo/Sluggable/Fixture/ArticleWithHistory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Sluggable\Fixture;
+
+use Gedmo\Sluggable\Sluggable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\SlugHistory(slugEntryClass="Sluggable\Fixture\History")
+ */
+class ArticleWithHistory implements Sluggable
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(name="code", type="string", length=16)
+     */
+    private $code;
+
+    /**
+     * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    private $slug;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}
+

--- a/tests/Gedmo/Sluggable/Fixture/History.php
+++ b/tests/Gedmo/Sluggable/Fixture/History.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sluggable\Fixture;
+
+use Gedmo\Sluggable\Entity\MappedSuperclass\AbstractSlugEntry;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="test_article_slug_entries")
+ * @ORM\Entity(repositoryClass="Gedmo\Sluggable\Entity\Repository\SlugEntryRepository")
+ */
+class History extends AbstractSlugEntry
+{
+
+}

--- a/tests/Gedmo/Sluggable/Fixture/TransArticleManySlugWithHistory.php
+++ b/tests/Gedmo/Sluggable/Fixture/TransArticleManySlugWithHistory.php
@@ -9,8 +9,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @Gedmo\SlugHistory(slugEntryClass="Sluggable\Fixture\History")
  */
-class TransArticleManySlug implements Sluggable, Translatable
+class TransArticleManySlugWithHistory implements Sluggable, Translatable
 {
     /**
      * @ORM\Id

--- a/tests/Gedmo/Sluggable/SluggableHistoryTest.php
+++ b/tests/Gedmo/Sluggable/SluggableHistoryTest.php
@@ -13,7 +13,7 @@ use Sluggable\Fixture\Article;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class SluggableTest extends BaseTestCaseORM
+class SluggableHistoryTest extends BaseTestCaseORM
 {
     const ARTICLE = 'Sluggable\\Fixture\\ArticleWithHistory';
     const ARTICLE_MANY = 'Sluggable\\Fixture\\TransArticleManySlugWithHistory';

--- a/tests/Gedmo/Sluggable/SluggableHistoryTest.php
+++ b/tests/Gedmo/Sluggable/SluggableHistoryTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Sluggable\Fixture\Article;
+
+/**
+ * These are tests for sluggable behavior
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class SluggableTest extends BaseTestCaseORM
+{
+    const ARTICLE = 'Sluggable\\Fixture\\ArticleWithHistory';
+    const ARTICLE_MANY = 'Sluggable\\Fixture\\TransArticleManySlugWithHistory';
+	const HISTORY = 'Sluggable\\Fixture\\History';
+
+    private $articleId;
+    private $transArticleId;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager;
+        $evm->addEventSubscriber(new SluggableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    /**
+     * @test
+     */
+    function shouldStoreSlugHistoryOnUpdate()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setTitle('the title updated');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		$historyRepository = $this->em->getRepository(self::HISTORY);
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE, $article);
+		$this->assertSame($this->articleId, $article->getId());
+
+        $article->setTitle('the title updated second time');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE, $article);
+		$this->assertSame($this->articleId, $article->getId());
+
+		$article = $historyRepository->findOneBySlug('the-title-updated-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE, $article);
+		$this->assertSame($this->articleId, $article->getId());
+    }
+
+    /**
+     * @test
+     */
+    function shouldDeleteHistoryOnEntityDelete()
+    {
+        $article = $this->em->find(self::ARTICLE, $this->articleId);
+        $article->setTitle('the title updated');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		// Remove entity
+		$this->em->remove($article);
+        $this->em->flush();
+
+		// Test that slug history for the entity were deleted
+		$historyRepository = $this->em->getRepository(self::HISTORY);
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNull($article);
+    }
+
+    /**
+     * @test
+     */
+    function shouldStoreSlugHistoryOnUpdateWithManySlugs()
+    {
+        $article = $this->em->find(self::ARTICLE_MANY, $this->articleId);
+        $article->setTitle('the title updated');
+		$article->setUniqueTitle('the unique title updated');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		$historyRepository = $this->em->getRepository(self::HISTORY);
+		// By slug
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+		// By uniqueSlug
+		$article = $historyRepository->findOneByUniqueSlug('the-unique-title');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+
+        $article->setTitle('the title updated second time');
+		$article->setUniqueTitle('the unique title updated second time');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		// The old old slug
+		// By slug
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+		// By uniqueSlug
+		$article = $historyRepository->findOneByUniqueSlug('the-unique-title');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+
+		// By slug
+		$article = $historyRepository->findOneBySlug('the-title-updated-my-code');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+		// By uniqueSlug
+		$article = $historyRepository->findOneByUniqueSlug('the-unique-title-updated');
+		$this->assertNotNull($article);
+		$this->assertInstanceOf(self::ARTICLE_MANY, $article);
+		$this->assertSame($this->articleId, $article->getId());
+    }
+
+    /**
+     * @test
+     */
+    function shouldDeleteHistoryOnEntityDeleteWithManySlugs()
+    {
+        $article = $this->em->find(self::ARTICLE_MANY, $this->articleId);
+        $article->setTitle('the title updated');
+		$article->setUniqueTitle('the unique title updated');
+        $this->em->persist($article);
+        $this->em->flush();
+
+		// Remove entity
+		$this->em->remove($article);
+        $this->em->flush();
+
+		$historyRepository = $this->em->getRepository(self::HISTORY);
+		$article = $historyRepository->findOneBySlug('the-title-my-code');
+		$this->assertNull($article);
+		$article = $historyRepository->findOneByUniqueSlug('the-unique-title');
+		$this->assertNull($article);
+    }
+
+	protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::ARTICLE,
+            self::ARTICLE_MANY,
+			self::HISTORY
+        );
+    }
+
+    private function populate()
+    {
+		$class = self::ARTICLE;
+        $article = new $class();
+        $article->setTitle('the title');
+        $article->setCode('my code');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+        $this->articleId = $article->getId();
+
+		$class = self::ARTICLE_MANY;
+        $article = new $class();
+        $article->setTitle('the title');
+        $article->setCode('my code');
+        $article->setUniqueTitle('the unique title');
+
+        $this->em->persist($article);
+        $this->em->flush();
+        $this->em->clear();
+        $this->transArticleId = $article->getId();
+    }
+}

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -70,10 +70,10 @@ class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
         $this->assertEquals($this->generatePath(array('1' => $category->getId(), '2' => $category2->getId())), $category2->getPath());
         $this->assertEquals($this->generatePath(array('1' => $category->getId(), '2' => $category2->getId(), '3' => $category3->getId())), $category3->getPath());
         $this->assertEquals($this->generatePath(array('4' => $category4->getId())), $category4->getPath());
-        $this->assertEquals(1, $category->getLevel());
-        $this->assertEquals(2, $category2->getLevel());
-        $this->assertEquals(3, $category3->getLevel());
-        $this->assertEquals(1, $category4->getLevel());
+        $this->assertEquals(0, $category->getLevel());
+        $this->assertEquals(1, $category2->getLevel());
+        $this->assertEquals(2, $category3->getLevel());
+        $this->assertEquals(0, $category4->getLevel());
 
         // Update
         $category2->setParent(null);
@@ -88,10 +88,10 @@ class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
         $this->assertEquals($this->generatePath(array('1' => $category->getId())), $category->getPath());
         $this->assertEquals($this->generatePath(array('2' => $category2->getId())), $category2->getPath());
         $this->assertEquals($this->generatePath(array('2' => $category2->getId(), '3' => $category3->getId())), $category3->getPath());
-        $this->assertEquals(1, $category->getLevel());
-        $this->assertEquals(1, $category2->getLevel());
-        $this->assertEquals(2, $category3->getLevel());
-        $this->assertEquals(1, $category4->getLevel());
+        $this->assertEquals(0, $category->getLevel());
+        $this->assertEquals(0, $category2->getLevel());
+        $this->assertEquals(1, $category3->getLevel());
+        $this->assertEquals(0, $category4->getLevel());
 
         // Remove
         $this->dm->remove($category);
@@ -104,7 +104,7 @@ class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 
         $this->assertEquals(1, $result->count());
         $this->assertEquals('4', $firstResult->getTitle());
-        $this->assertEquals(1, $firstResult->getLevel());
+        $this->assertEquals(0, $firstResult->getLevel());
     }
 
     /**

--- a/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMRepositoryTest.php
@@ -261,7 +261,7 @@ class MaterializedPathORMRepositoryTest extends BaseTestCaseORM
         $this->em->flush();
 
         $this->assertRegexp('/Food\-\d+,New\sNode\-\d+/', $newNode->getPath());
-        $this->assertEquals(2, $newNode->getLevel());
+        $this->assertEquals(1, $newNode->getLevel());
     }
 
     public function test_changeChildrenIndex()

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -68,10 +68,10 @@ class MaterializedPathORMTest extends BaseTestCaseORM
         $this->assertEquals($this->generatePath(array('1' => $category->getId(), '2' => $category2->getId())), $category2->getPath());
         $this->assertEquals($this->generatePath(array('1' => $category->getId(), '2' => $category2->getId(), '3' => $category3->getId())), $category3->getPath());
         $this->assertEquals($this->generatePath(array('4' => $category4->getId())), $category4->getPath());
-        $this->assertEquals(1, $category->getLevel());
-        $this->assertEquals(2, $category2->getLevel());
-        $this->assertEquals(3, $category3->getLevel());
-        $this->assertEquals(1, $category4->getLevel());
+        $this->assertEquals(0, $category->getLevel());
+        $this->assertEquals(1, $category2->getLevel());
+        $this->assertEquals(2, $category3->getLevel());
+        $this->assertEquals(0, $category4->getLevel());
 
         // Update
         $category2->setParent(null);
@@ -86,10 +86,10 @@ class MaterializedPathORMTest extends BaseTestCaseORM
         $this->assertEquals($this->generatePath(array('1' => $category->getId())), $category->getPath());
         $this->assertEquals($this->generatePath(array('2' => $category2->getId())), $category2->getPath());
         $this->assertEquals($this->generatePath(array('2' => $category2->getId(), '3' => $category3->getId())), $category3->getPath());
-        $this->assertEquals(1, $category->getLevel());
-        $this->assertEquals(1, $category2->getLevel());
-        $this->assertEquals(2, $category3->getLevel());
-        $this->assertEquals(1, $category4->getLevel());
+        $this->assertEquals(0, $category->getLevel());
+        $this->assertEquals(0, $category2->getLevel());
+        $this->assertEquals(1, $category3->getLevel());
+        $this->assertEquals(0, $category4->getLevel());
 
         // Remove
         $this->em->remove($category);
@@ -102,7 +102,7 @@ class MaterializedPathORMTest extends BaseTestCaseORM
 
         $this->assertCount(1, $result);
         $this->assertEquals('4', $firstResult->getTitle());
-        $this->assertEquals(1, $firstResult->getLevel());
+        $this->assertEquals(0, $firstResult->getLevel());
     }
 
     /**


### PR DESCRIPTION
Hi,

I implemented ability to setup sluggable to store old slugs in the separate table when you update entity. After that you can use repository of the history entity and make a query which will return object which has the slug in the past.

E.g. if you create an article with slug *great-application*. After some time you decide to change the slug to *very-great-application*. You can load the article by old slug and redirect user to new one, which is better than throwing 404

I make this feature for Annotation driver and ORM. If somebody can make it for other drivers it would be great.
