### PR TITLE
[Tree][Closure] Handle primary key differents types

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Tree\Strategy\ORM;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Version;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\EntityManager;
@@ -282,7 +283,7 @@ class Closure implements Strategy
             }
 
             $typeId = $meta->fieldMappings[$identifier]['type'];
-            $type = \Doctrine\DBAL\Types\Type::getType($typeId);
+            $type = Type::getType($typeId);
 
             foreach ($entries as $closure) {
                 $closure[$ancestorColumnName] = $type->convertToDatabaseValue($closure[$ancestorColumnName], $em->getConnection()->getDatabasePlatform());

--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -281,7 +281,13 @@ class Closure implements Strategy
                 $ea->setOriginalObjectProperty($uow, spl_object_hash($node), $config['level'], 1);
             }
 
+            $typeId = $meta->fieldMappings[$identifier]['type'];
+            $type = \Doctrine\DBAL\Types\Type::getType($typeId);
+
             foreach ($entries as $closure) {
+                $closure[$ancestorColumnName] = $type->convertToDatabaseValue($closure[$ancestorColumnName], $em->getConnection()->getDatabasePlatform());
+                $closure[$descendantColumnName] = $type->convertToDatabaseValue($closure[$descendantColumnName], $em->getConnection()->getDatabasePlatform());
+
                 if (!$em->getConnection()->insert($closureTable, $closure)) {
                     throw new RuntimeException('Failed to insert new Closure record');
                 }

--- a/tests/Gedmo/Tree/Fixture/Closure/CustomCategory.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CustomCategory.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tree\Fixture\Closure;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @Gedmo\Tree(type="closure")
+ * @Gedmo\TreeClosure(class="Tree\Fixture\Closure\CustomCategoryClosure")
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
+ */
+class CustomCategory
+{
+    /**
+     * @ORM\Column(name="id", type="custom_tree")
+     * @ORM\Id
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(name="level", type="integer", nullable=true)
+     * @Gedmo\TreeLevel
+     */
+    private $level;
+
+    /**
+     * @Gedmo\TreeParent
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * @ORM\ManyToOne(targetEntity="CustomCategory", inversedBy="children")
+     */
+    private $parent;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setParent(CustomCategory $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function addClosure(CustomCategoryClosure $closure)
+    {
+        $this->closures[] = $closure;
+    }
+
+    public function setLevel($level)
+    {
+        $this->level = $level;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+}

--- a/tests/Gedmo/Tree/Fixture/Closure/CustomCategoryClosure.php
+++ b/tests/Gedmo/Tree/Fixture/Closure/CustomCategoryClosure.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tree\Fixture\Closure;
+
+use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CustomCategoryClosure extends AbstractClosure
+{
+
+}

--- a/tests/Gedmo/Tree/Fixture/Type/Custom.php
+++ b/tests/Gedmo/Tree/Fixture/Type/Custom.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tree\Fixture\Type;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class Custom extends Type
+{
+    const NAME = 'custom_tree';
+
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+       return $value;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+}


### PR DESCRIPTION
Hi,

I have a problem with an entity with `TreeListener` (type closure). 

My entity primary key is a custom doctrine type, but the `Closure::processPostPersist` doesn't care. So I modified the behavior to take care about this information.

Let me know if anything looks wrong for you.
