### PR TITLE
[Sortable] Test reproducing a bug: moving an entity to the last position

### DIFF
--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -542,6 +542,35 @@ class SortableTest extends BaseTestCaseORM
         $this->assertEquals(4, $nodes[4]->getPosition());
     }
 
+    /**
+     * @test
+     */
+    public function testMoveToLastPosition()
+    {
+        $node0 = $this->em->find(self::NODE, $this->nodeId);
+
+        $nodes = array($node0);
+
+        for ($i = 2; $i <= 5; $i++) {
+            $node = new Node();
+            $node->setName("Node".$i);
+            $node->setPath("/");
+            $this->em->persist($node);
+            $nodes[] = $node;
+        }
+        $this->em->flush();
+
+        $this->assertEquals(4, $nodes[4]->getPosition());
+
+        $node0->setPosition(-1);
+
+        $this->em->persist($node0);
+        $this->em->flush();
+
+        $this->assertEquals(3, $nodes[4]->getPosition());
+        $this->assertEquals(4, $node0->getPosition());
+    }
+
     protected function getUsedEntityFixtures()
     {
         return array(


### PR DESCRIPTION
Moving an object to the last position using the `-1` position doesn't work.

The new position is not the last one, but the last one + 1, which result in a gap:
- 0
- 1
- 3 (should be 2)

This PR contains a test reproducing the problem.

I tried figuring out the source of the problem, I think it's that when moving to a negative number, the new position is not the correct one:
- A (0)
- B (1)

`A.setPosition(-1)`

In SortableListener: `$newPosition += $this->maxPositions[$hash] + 2; // position == -1 => append at end of list`
- A.position = -1 + MAX + 2 = 2 (should be 1)
- B.position = 0 (correct)
