### PR TITLE
update objectId type form string to integer

### DIFF
--- a/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -37,7 +37,7 @@ abstract class AbstractLogEntry
     /**
      * @var string $objectId
      *
-     * @ORM\Column(name="object_id", length=64, nullable=true)
+     * @ORM\Column(name="object_id", type="integer", nullable=true)
      */
     protected $objectId;
 


### PR DESCRIPTION
update objectId type form string to integer

I think it's wrong to create objectId as an string in Gedmo/Loggable/Entity/AbstractLogEntry.php changed to integer
