### PR TITLE
Bug fix for empty or "0" translated values

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -459,14 +459,16 @@ class TranslatableListener extends MappedEventSubscriber
             // translate object's translatable properties
             foreach ($config['fields'] as $field) {
                 $translated = '';
+                $isTranslated = false;
                 foreach ((array)$result as $entry) {
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'];
+                        $isTranslated = true;
                         break;
                     }
                 }
                 // update translation
-                if ($translated
+                if ($isTranslated
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {


### PR DESCRIPTION
It is very bad to rely on the translation value to check if the field has been translated. The check would never return true if the value in the translation entity is either empty ("") or zero.

A better way would be using a separate flag just for the check.
