### PR TITLE
Allow EntityWrapper to also wrap EntityManagerDecorators 

### DIFF
--- a/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
@@ -2,7 +2,7 @@
 
 namespace Gedmo\Tool\Wrapper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
 
 /**
@@ -32,9 +32,9 @@ class EntityWrapper extends AbstractWrapper
      * Wrap entity
      *
      * @param object $entity
-     * @param \Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManagerInterface $em
      */
-    public function __construct($entity, EntityManager $em)
+    public function __construct($entity, EntityManagerInterface $em)
     {
         $this->om = $em;
         $this->object = $entity;

--- a/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/AbstractTreeRepository.php
@@ -2,8 +2,8 @@
 
 namespace Gedmo\Tree\Entity\Repository;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository,
-    Doctrine\ORM\EntityManager,
     Doctrine\ORM\Mapping\ClassMetadata,
     Gedmo\Tool\Wrapper\EntityWrapper,
     Gedmo\Tree\RepositoryUtils,
@@ -28,7 +28,7 @@ abstract class AbstractTreeRepository extends EntityRepository implements Reposi
     /**
      * {@inheritdoc}
      */
-    public function __construct(EntityManager $em, ClassMetadata $class)
+    public function __construct(EntityManagerInterface $em, ClassMetadata $class)
     {
         parent::__construct($em, $class);
         $treeListener = null;

--- a/lib/Gedmo/Tree/TreeListener.php
+++ b/lib/Gedmo/Tree/TreeListener.php
@@ -72,14 +72,13 @@ class TreeListener extends MappedEventSubscriber
                 throw new \Gedmo\Exception\UnexpectedValueException("Tree object class: {$class} must have tree metadata at this point");
             }
             $managerName = 'UnsupportedManager';
-            if ($om instanceof \Doctrine\ORM\EntityManager) {
+            if ($om instanceof \Doctrine\ORM\EntityManagerInterface) {
                 $managerName = 'ORM';
             } elseif ($om instanceof \Doctrine\ODM\MongoDB\DocumentManager) {
                 $managerName = 'ODM\\MongoDB';
             }
             if (!isset($this->strategyInstances[$config['strategy']])) {
                 $strategyClass = $this->getNamespace().'\\Strategy\\'.$managerName.'\\'.ucfirst($config['strategy']);
-                
                 if (!class_exists($strategyClass)) {
                     throw new \Gedmo\Exception\InvalidArgumentException($managerName." TreeListener does not support tree type: {$config['strategy']}");
                 }

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -53,8 +53,10 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
      * annotation mapping driver and pdo_sqlite
      * database in memory
      *
-     * @param EventManager $evm
-     * @return EntityManager
+     * @param EventManager                $evm
+     * @param \Doctrine\ORM\Configuration $config
+     *
+     * @return DecoratedEntityManager
      */
     protected function getMockSqliteEntityManager(EventManager $evm = null, Configuration $config = null)
     {
@@ -74,7 +76,7 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
         $schemaTool->dropSchema(array());
         $schemaTool->createSchema($schema);
 
-        return $this->em = $em;
+        return $this->em = new DecoratedEntityManager($em);
     }
 
     /**
@@ -84,7 +86,7 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
      *
      * @param array $conn
      * @param EventManager $evm
-     * @return EntityManager
+     * @return DecoratedEntityManager
      */
     protected function getMockCustomEntityManager(array $conn, EventManager $evm = null)
     {
@@ -99,7 +101,7 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
         $schemaTool->dropSchema(array());
         $schemaTool->createSchema($schema);
 
-        return $this->em = $em;
+        return $this->em = new DecoratedEntityManager($em);
     }
 
     /**
@@ -107,7 +109,7 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
      * annotation mapping driver
      *
      * @param EventManager $evm
-     * @return EntityManager
+     * @return DecoratedEntityManager
      */
     protected function getMockMappedEntityManager(EventManager $evm = null)
     {
@@ -122,7 +124,7 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($evm ?: $this->getEventManager()));
 
         $config = $this->getMockAnnotatedConfig();
-        $this->em = EntityManager::create($conn, $config);
+        $this->em = new DecoratedEntityManager(EntityManager::create($conn, $config));
 
         return $this->em;
     }

--- a/tests/Gedmo/Tool/DecoratedEntityManager.php
+++ b/tests/Gedmo/Tool/DecoratedEntityManager.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tool;
+
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+
+class DecoratedEntityManager extends EntityManagerDecorator
+{
+
+}


### PR DESCRIPTION
Or anything that implements EntityManagerInterface.

I ran into the issue using NestedTree.  I modified BaseTestCaseORM to decorate the mocks returned by the three getMock*EntityManager() methods, and fixed all tests that failed by changing EntityWrapper to type-hint EntityManagerInterface instead of EntityManager.
