### PR TITLE
Adds more datetime types and changes exceptions to list all supported types

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -46,6 +46,9 @@ class Annotation extends AbstractAnnotationDriver
         'integer',
         'int',
         'datetime',
+        'date',
+        'datetimez',
+        'time'
     );
 
     /**
@@ -103,7 +106,8 @@ class Annotation extends AbstractAnnotationDriver
                         throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
                     }
                     if (!$this->isValidField($meta, $slugField)) {
-                        throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be 'string' or 'text' in class - {$meta->name}");
+                        $types = implode(', ', $this->validTypes);
+                        throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be [{$types}] in class - {$meta->name}");
                     }
                 }
                 if (!is_bool($slug->updatable)) {

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -29,6 +29,9 @@ class Xml extends BaseXml
         'integer',
         'int',
         'datetime',
+        'date',
+        'datetimez',
+        'time'
     );
 
     /**
@@ -63,8 +66,10 @@ class Xml extends BaseXml
                         if (!$meta->hasField($slugField)) {
                             throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
                         }
+                        
                         if (!$this->isValidField($meta, $slugField)) {
-                            throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be 'string' or 'text' in class - {$meta->name}");
+                            $types = implode(', ', $this->validTypes);
+                            throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be [{$types}] in class - {$meta->name}");
                         }
                     }
 

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -34,6 +34,9 @@ class Yaml extends File implements Driver
         'integer',
         'int',
         'datetime',
+        'date',
+        'datetimez',
+        'time'
     );
 
     /**
@@ -71,7 +74,8 @@ class Yaml extends File implements Driver
                                 throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
                             }
                             if (!$this->isValidField($meta, $slugField)) {
-                                throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be 'string' or 'text' in class - {$meta->name}");
+                                $types = implode(', ', $this->validTypes);
+                                throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be [{$types}] in class - {$meta->name}");
                             }
                         }
 


### PR DESCRIPTION
Hi,

Doctrine changes datetime, datetimez, date and time type to \DateTime PHP object, so I think it is logical to add these types to supported list.

Also exception message should be more informative to display all supported types
