### PR TITLE
Single Table Inheritance getSimilarSlugs issue

### DIFF
--- a/tests/Gedmo/Sluggable/Fixture/Inheritance3/Bike.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance3/Bike.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sluggable\Fixture\Inheritance3;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Bike extends VehicleWithSlug
+{
+    
+}

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance3/Car.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance3/Car.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sluggable\Fixture\Inheritance3;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Car extends VehicleWithSlug
+{
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance3/Vehicle.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance3/Vehicle.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sluggable\Fixture\Inheritance3;
+
+use Doctrine\ORM\Mapping as ORM;
+
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ * @ORM\DiscriminatorMap({
+ *      "vehicle" = "Vehicle",
+ *      "vehiclewithslug" = "VehicleWithSlug",
+ *      "bike" = "Bike",
+ *      "car" = "Car"
+ * })
+ */
+class Vehicle
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    
+}

--- a/tests/Gedmo/Sluggable/Fixture/Inheritance3/VehicleWithSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Inheritance3/VehicleWithSlug.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sluggable\Fixture\Inheritance3;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+/**
+ * @ORM\Entity
+ */
+class VehicleWithSlug extends Vehicle
+{
+    /**
+     * @Gedmo\Slug(fields={"title"})
+     * @ORM\Column(length=128, unique=true)
+     */
+    private $slug;
+    
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+    
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Inheritance3Test.php
+++ b/tests/Gedmo/Sluggable/Inheritance3Test.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Sluggable\Fixture\Inheritance3\Car;
+use Sluggable\Fixture\Inheritance3\Vehicle;
+use Sluggable\Fixture\Inheritance3\VehicleWithSlug;
+use Sluggable\Fixture\Inheritance3\Bike;
+
+/**
+ * These are tests for Sluggable behavior
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class Inheritance3Test extends BaseTestCaseORM
+{
+    const VEHICLE = 'Sluggable\\Fixture\\Inheritance3\\Vehicle';
+    const VEHICLE_WITH_SLUG = 'Sluggable\\Fixture\\Inheritance3\\VehicleWithSlug';
+    const CAR = 'Sluggable\\Fixture\\Inheritance3\\Car';
+    const BIKE = 'Sluggable\\Fixture\\Inheritance3\\Bike';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager;
+        $evm->addEventSubscriber(new SluggableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    public function testSlugGeneration()
+    {
+        $audi = new Car;
+        $audi->setDescription('audi car');
+        $audi->setTitle('Audi');
+
+        $this->em->persist($audi);
+        $this->em->flush();
+        
+        $bike = new Bike;
+        $bike->setTitle('Audi');
+
+        $this->em->persist($bike);
+        $this->em->flush();
+
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::VEHICLE,
+            self::VEHICLE_WITH_SLUG,
+            self::CAR,
+            self::BIKE,
+        );
+    }
+}


### PR DESCRIPTION
If the top-most parent class, does not have slug field but, the parent class in the middle has one. The getSimilarSlugs could not find similar slugs, causing SQL error in the database. 
Submitted a test case and a fix. Hope it gets soon into master.
