### PR TITLE
Fix - Add control - if newValue is object

### DIFF
--- a/lib/Gedmo/Blameable/BlameableListener.php
+++ b/lib/Gedmo/Blameable/BlameableListener.php
@@ -82,7 +82,7 @@ class BlameableListener extends TimestampableListener
         $newValue = $this->getUserValue($meta, $field);
 
         //if blame is reference, persist object
-        if ($meta->hasAssociation($field)) {
+        if (is_object($newValue) && $meta->hasAssociation($field)) {
             $ea->getObjectManager()->persist($newValue);
         }
         $property->setValue($object, $newValue);


### PR DESCRIPTION
[Doctrine\ORM\ORMInvalidArgumentException]  
  EntityManager#persist() expects parameter 1 to be an entity object, NULL given.

Closes #1074
