### PR TITLE
Fixes Translatable with PersonalTranslation

### DIFF
--- a/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
@@ -136,7 +136,11 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
         $qb->setParameters(compact('locale', 'field'));
         if ($this->usesPersonalTranslation($translationClass)) {
             $qb->andWhere('trans.object = :object');
-            $qb->setParameter('object', $wrapped->getObject());
+            if($wrapped->getIdentifier()) {
+                $qb->setParameter('object', $wrapped->getObject());
+            } else {
+                $qb->setParameter('object', null);
+            }
         } else {
             $qb->andWhere('trans.foreignKey = :objectId');
             $qb->andWhere('trans.objectClass = :objectClass');


### PR DESCRIPTION
When not using PersonalTranslation, $wrapped->getIdentifier() is used in the query, which returns NULL, so the query looks like "WHERE trans.foreignKey = NULL", perfectly fine.
However, when using PersonalTranslation, the object is not yet persisted, and Doctrine can't "find" its id, so I added a condition that verifies if the object has already been persisted or not, and, if it hasn't, uses NULL instead of the object.
If the object is not yet persisted, except if I'm wrong, we can assume it doesn't have any stored translation yet, so this shouldn't break anything