### PR TITLE
Fix Entity identifier handling for ancestors

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -266,7 +266,7 @@ class Closure implements Strategy
 
                 foreach ($ancestors as $ancestor) {
                     $entries[] = array(
-                        $ancestorColumnName => $ancestor['ancestor']['id'],
+                        $ancestorColumnName => $ancestor['ancestor'][$identifier],
                         $descendantColumnName => $nodeId,
                         $depthColumnName => $ancestor['depth'] + 1
                     );


### PR DESCRIPTION
Use the Entity's defined single identifier field column name rather than hardcoded 'id' when getting data from the ancestor result array in the processPostPersist method.
