### PR TITLE
Versioned class and inherited fileds for annotation configuration

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -63,6 +63,7 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
+        $versionedFieldList = null;
         if ($annotation = $this->reader->getClassAnnotation($class, self::VERSIONED_CLASS_AND_INHERITED_FIELDS)) {
             $versionedFieldList = $annotation->getFieldList();
         }

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -64,7 +64,7 @@ class Annotation extends AbstractAnnotationDriver
         }
 
         if ($annotation = $this->reader->getClassAnnotation($class, self::VERSIONED_CLASS_AND_INHERITED_FIELDS)) {
-            $versionedFiledList = $annotation->getFiledList();
+            $versionedFieldList = $annotation->getFieldList();
         }
 
         // property annotations
@@ -82,7 +82,7 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
                 }
                 // fields cannot be overrided and throws mapping exception
-                $config['versioned'][] = $this->compareWithClassAndInheritedFields($field, $versionedFiledList);
+                $config['versioned'][] = $this->compareWithClassAndInheritedFields($field, $versionedFieldList);
             }
         }
 
@@ -98,15 +98,17 @@ class Annotation extends AbstractAnnotationDriver
 
     /**
      * @param $field
-     * @param $versionedFiledList
-     * @return string
+     * @param $versionedFieldList
+     * @return mixed
      */
-    protected function compareWithClassAndInheritedFields($field, $versionedFiledList)
+    protected function compareWithClassAndInheritedFields($field, $versionedFieldList)
     {
-        if (null != $versionedFiledList) {
-            if (in_array($field, $versionedFiledList)) {
+        if (null != $versionedFieldList) {
+            if (in_array($field, $versionedFieldList)) {
                 return $field;
             }
         }
+
+        return $field;
     }
 }

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -63,7 +63,7 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
-        $versionedFieldList = null;
+        $versionedFieldList = [];
         if ($annotation = $this->reader->getClassAnnotation($class, self::VERSIONED_CLASS_AND_INHERITED_FIELDS)) {
             $versionedFieldList = $annotation->getFieldList();
         }
@@ -100,11 +100,11 @@ class Annotation extends AbstractAnnotationDriver
     /**
      * @param $field
      * @param $versionedFieldList
-     * @return mixed
+     * @return string
      */
     protected function compareWithClassAndInheritedFields($field, $versionedFieldList)
     {
-        if (null != $versionedFieldList) {
+        if ([] != $versionedFieldList) {
             if (in_array($field, $versionedFieldList)) {
                 return $field;
             }

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -63,7 +63,7 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
-        $versionedFieldList = [];
+        $versionedFieldList = array();
         if ($annotation = $this->reader->getClassAnnotation($class, self::VERSIONED_CLASS_AND_INHERITED_FIELDS)) {
             $versionedFieldList = $annotation->getFieldList();
         }
@@ -104,7 +104,7 @@ class Annotation extends AbstractAnnotationDriver
      */
     protected function compareWithClassAndInheritedFields($field, $versionedFieldList)
     {
-        if ([] != $versionedFieldList) {
+        if (is_array($versionedFieldList)) {
             if (in_array($field, $versionedFieldList)) {
                 return $field;
             }

--- a/lib/Gedmo/Mapping/Annotation/All.php
+++ b/lib/Gedmo/Mapping/Annotation/All.php
@@ -33,6 +33,7 @@ include __DIR__.'/TreePathSource.php';
 include __DIR__.'/TreeRight.php';
 include __DIR__.'/TreeRoot.php';
 include __DIR__.'/Versioned.php';
+include __DIR__.'/VersionedClassAndInheritedFields.php';
 include __DIR__.'/Uploadable.php';
 include __DIR__.'/UploadableFileMimeType.php';
 include __DIR__.'/UploadableFilePath.php';

--- a/lib/Gedmo/Mapping/Annotation/VersionedClassAndInheritedFields.php
+++ b/lib/Gedmo/Mapping/Annotation/VersionedClassAndInheritedFields.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gedmo\Mapping\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Loggable annotation for Loggable behavioral extension
+ *
+ * @Annotation
+ * @Target("CLASS")
+ *
+ * @author Krzysztof Cholewka <cholewka.krzysztof@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+final class VersionedClassAndInheritedFields extends Annotation
+{
+    protected $fieldList;
+
+    public function getFiledList()
+    {
+        return $this->fieldList;
+    }
+}
+

--- a/lib/Gedmo/Mapping/Annotation/VersionedClassAndInheritedFields.php
+++ b/lib/Gedmo/Mapping/Annotation/VersionedClassAndInheritedFields.php
@@ -5,7 +5,7 @@ namespace Gedmo\Mapping\Annotation;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
- * Loggable annotation for Loggable behavioral extension
+ * VersionedClassAndInheritedFields annotation for Loggable behavioral extension
  *
  * @Annotation
  * @Target("CLASS")
@@ -15,9 +15,15 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class VersionedClassAndInheritedFields extends Annotation
 {
+    /**
+     * @var array
+     */
     protected $fieldList;
 
-    public function getFiledList()
+    /**
+     * @return array
+     */
+    public function getFieldList()
     {
         return $this->fieldList;
     }


### PR DESCRIPTION
This annotation allows to define list of fields which will be versioned. By default all inherited fields and marked as `@Gedmo\Versioned` will be logged but sometimes we would like to specify that only few of them should be versioned.

Example:

``` php

use Gedmo\Mapping\Annotation as Gedmo;

class Person
{
    /**
     * @Gedmo\Versioned
     */
    protected $age;
}

/**
 * @Gedmo\VersionedClassAndInheritedFields(fieldList={"skill"})
 */
class Worker extends Person
{
    /**
     * @Gedmo\Versioned
     */
    protected $skill;
}
```

Now - because annotation VersionedClassAndInheritedFields has been used - versioned will be only this field. If this annotation will be not used than all fields from class Worker and inherited form Person (age, skill) will be versioned.
