### PR TITLE
Add support for a treeRoot with value NULL

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -579,14 +579,16 @@ class Nested implements Strategy
             ->andWhere($qb->expr()->lte('node.'.$config['right'], $last))
         ;
         if (isset($config['root'])) {
-            $qb->set(
-                'node.'.$config['root'],
-                is_string($destRootId) ? $qb->expr()->literal($destRootId) : $destRootId
-            );
-            $qb->andWhere($rootId === null ?
-                $qb->expr()->isNull('node.'.$config['root']) :
-                $qb->expr()->eq('node.'.$config['root'], is_string($rootId) ? $qb->expr()->literal($rootId) : $rootId)
-            );
+            if ($destRootId === null) {
+                $qb->set('node.'.$config['root'], 'NULL');
+                $qb->andWhere($qb->expr()->isNull('node.'.$config['root']));
+            } else {
+                $qb->set(
+                    'node.'.$config['root'],
+                    is_string($destRootId) ? $qb->expr()->literal($destRootId) : $destRootId
+                );
+                $qb->andWhere($qb->expr()->eq('node.'.$config['root'], is_string($rootId) ? $qb->expr()->literal($rootId) : $rootId));
+            }
         }
         if (isset($config['level'])) {
             $qb->set('node.'.$config['level'], "node.{$config['level']} {$levelSign} {$absLevelDelta}");


### PR DESCRIPTION
Previously you would get an SQL error when trying to insert a node into
a tree where treeRoot was NULL. Now it handles it fine.