### PR TITLE
change visibility of fields in BlameableEntity.php

### DIFF
--- a/lib/Gedmo/Blameable/Traits/BlameableEntity.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableEntity.php
@@ -15,14 +15,14 @@ trait BlameableEntity
      * @Gedmo\Blameable(on="create")
      * @ORM\Column(type="string", nullable=true)
      */
-    private $createdBy;
+    protected $createdBy;
 
     /**
      * @var string
      * @Gedmo\Blameable(on="update")
      * @ORM\Column(type="string", nullable=true)
      */
-    private $updatedBy;
+    protected $updatedBy;
 
     /**
      * Sets createdBy.


### PR DESCRIPTION
Change visibility of entity fields from private to protected in BlameableEntity.php. 
Protected is already exists in Timestampable trait.
