### PR TITLE
Fix for uploading same named files.

### DIFF
--- a/lib/Gedmo/Uploadable/UploadableListener.php
+++ b/lib/Gedmo/Uploadable/UploadableListener.php
@@ -593,6 +593,14 @@ class UploadableListener extends MappedEventSubscriber
 
         if (is_file($info['filePath'])) {
             if ($overwrite) {
+                
+                $k = array_search($info['filePath'], $this->pendingFileRemovals);
+                
+                if ($k !== false)
+                {
+                    unset($this->pendingFileRemovals[$k]);
+                }
+                
                 $this->removeFile($info['filePath']);
             } else if ($appendNumber) {
                 $counter = 1;


### PR DESCRIPTION
When uploading a file that has identical name as the file that has been previously uploaded for an entity the new file gets uploaded and deleted instantly. This fix removes the uploaded file from the pendingFileRemovals list.