### PR TITLE
Do not update field if blame is null

### DIFF
--- a/lib/Gedmo/Blameable/BlameableListener.php
+++ b/lib/Gedmo/Blameable/BlameableListener.php
@@ -81,6 +81,10 @@ class BlameableListener extends TimestampableListener
         $oldValue = $property->getValue($object);
         $newValue = $this->getUserValue($meta, $field);
 
+	if (null === $newValue) {
+            return;
+        }
+
         //if blame is reference, persist object
         if ($meta->hasAssociation($field)) {
             $ea->getObjectManager()->persist($newValue);


### PR DESCRIPTION
This one can produce exception when blame is unable to determine:

EntityManager#persist() expects parameter 1 to be an entity object, NULL given.
Scenario: updating entity through CRON tasks.