### PR TITLE
Make trait's properties protected

### DIFF
--- a/lib/Gedmo/Blameable/Traits/BlameableDocument.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableDocument.php
@@ -17,14 +17,14 @@ trait BlameableDocument
      * @Gedmo\Blameable(on="create")
      * @ODM\String
      */
-    private $createdBy;
+    protected $createdBy;
 
     /**
      * @var string
      * @Gedmo\Blameable(on="update")
      * @ODM\String
      */
-    private $updatedBy;
+    protected $updatedBy;
 
     /**
      * Sets createdBy.

--- a/lib/Gedmo/Blameable/Traits/BlameableEntity.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableEntity.php
@@ -17,14 +17,14 @@ trait BlameableEntity
      * @Gedmo\Blameable(on="create")
      * @ORM\Column(type="string", nullable=true)
      */
-    private $createdBy;
+    protected $createdBy;
 
     /**
      * @var string
      * @Gedmo\Blameable(on="update")
      * @ORM\Column(type="string", nullable=true)
      */
-    private $updatedBy;
+    protected $updatedBy;
 
     /**
      * Sets createdBy.

--- a/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
+++ b/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
@@ -17,14 +17,14 @@ trait IpTraceableDocument
      * @Gedmo\IpTraceable(on="create")
      * @ODM\String
      */
-    private $createdFromIp;
+    protected $createdFromIp;
 
     /**
      * @var string
      * @Gedmo\IpTraceable(on="update")
      * @ODM\String
      */
-    private $updatedFromIp;
+    protected $updatedFromIp;
 
     /**
      * Sets createdFromIp.

--- a/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
@@ -17,14 +17,14 @@ trait TimestampableDocument
      * @Gedmo\Timestampable(on="create")
      * @ODM\Date
      */
-    private $createdAt;
+    protected $createdAt;
 
     /**
      * @var \DateTime
      * @Gedmo\Timestampable(on="update")
      * @ODM\Date
      */
-    private $updatedAt;
+    protected $updatedAt;
 
     /**
      * Sets createdAt.


### PR DESCRIPTION
In my TYPO3 Flow project, Doctrine migration can't see private properties. They need to be protected in order to be included in the schema.