### PR TITLE
Change translation request for postgresql platform fix #1168

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -313,13 +313,17 @@ class TranslationWalker extends SqlWalker
                 $identifier = $meta->getSingleIdentifierFieldName();
                 $idColName = $meta->getQuotedColumnName($identifier, $this->platform);
                 if ($ea->usesPersonalTranslation($transClass)) {
-                    $sql .= ' AND '.$tblAlias.'.'.$transMeta->getSingleAssociationJoinColumnName('object')
-                        .' = '.$compTblAlias.'.'.$idColName;
+                    $sql .= ' AND '.$tblAlias.'.'.$transMeta->getSingleAssociationJoinColumnName('object');
                 } else {
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('objectClass', $this->platform)
                         .' = '.$this->conn->quote($meta->name);
-                    $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform)
-                        .' = '.$compTblAlias.'.'.$idColName;
+                    $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform);
+                }
+                //Add fix for postgresql casts of foreignKey field
+                if ($this->platform instanceof \Doctrine\DBAL\Platforms\PostgreSqlPlatform) {
+                    $sql .= ' = CAST('.$compTblAlias.'.'.$idColName.' AS "varchar")';
+                } else {
+                    $sql .' = '.$compTblAlias.'.'.$idColName;
                 }
                 isset($this->components[$dqlAlias]) ? $this->components[$dqlAlias] .= $sql : $this->components[$dqlAlias] = $sql;
 


### PR DESCRIPTION
Hi, 
i've posted #1168 2 weeks ago, and here is a little fix for this

Use case: 
Postgresql 9.3 

Something like that: 

$qv = $this->getEntityManager()->createQuery($dqlValidities);
        $qv->setHint(
            \Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER,
            'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker'
        );
        $qv->setHint(TranslatableListener::HINT_TRANSLATABLE_LOCALE,$locale);

was failing because of type difference between foreign_key field and the generated query.

This pr solve that.

Thanks