### PR TITLE
Fix MongoDB SortableGroup on a reference document

### DIFF
--- a/lib/Gedmo/Sortable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Sortable/Mapping/Event/Adapter/ODM.php
@@ -4,6 +4,7 @@ namespace Gedmo\Sortable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * Doctrine event adapter for ODM adapted
@@ -20,7 +21,11 @@ final class ODM extends BaseAdapterODM implements SortableAdapter
 
         $qb = $dm->createQueryBuilder($config['useObjectClass']);
         foreach ($groups as $group => $value) {
-            $qb->field($group)->equals($value);
+            if (is_object($value) && !$dm->getMetadataFactory()->isTransient(ClassUtils::getClass($value))) {
+                $qb->field($group)->references($value);
+            } else {
+                $qb->field($group)->equals($value);
+            }
         }
         $qb->sort($config['position'], 'desc');
         $document = $qb->getQuery()->getSingleResult();
@@ -47,7 +52,11 @@ final class ODM extends BaseAdapterODM implements SortableAdapter
             $qb->field($config['position'])->lt($delta['stop']);
         }
         foreach ($relocation['groups'] as $group => $value) {
-            $qb->field($group)->equals($value);
+            if (is_object($value) && !$dm->getMetadataFactory()->isTransient(ClassUtils::getClass($value))) {
+                $qb->field($group)->references($value);
+            } else {
+                $qb->field($group)->equals($value);
+            }
         }
 
         $qb->getQuery()->execute();

--- a/tests/Gedmo/Sortable/Fixture/Document/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Category.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sortable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\Document(collection="categories")
+ */
+class Category
+{
+    /** @ODM\Id */
+    private $id;
+
+    /**
+     * @ODM\String
+     */
+    private $name;
+
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Sortable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\Document(collection="kids")
+ */
+class Kid
+{
+    /** @ODM\Id */
+    private $id;
+
+    /**
+     * @ODM\String
+     */
+    private $lastname;
+
+    /**
+     * @Gedmo\SortablePosition
+     * @ODM\Field(type="int")
+     */
+    protected $position;
+
+    /**
+     * @Gedmo\SortableGroup
+     * @ODM\Field(type="date")
+     */
+    protected $birthdate;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setLastname($lastname)
+    {
+        $this->lastname = $lastname;
+    }
+
+    public function getLastname()
+    {
+        return $this->lastname;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setBirthdate(\DateTime $birthdate)
+    {
+        $this->birthdate = $birthdate;
+    }
+
+    public function getBirthdate()
+    {
+        return $this->birthdate;
+    }
+}

--- a/tests/Gedmo/Sortable/Fixture/Document/Post.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Post.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Sortable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Sortable\Fixture\Document\Category;
+
+/**
+ * @ODM\Document(collection="posts")
+ */
+class Post
+{
+    /** @ODM\Id */
+    private $id;
+
+    /**
+     * @ODM\String
+     */
+    private $title;
+
+    /**
+     * @Gedmo\SortablePosition
+     * @ODM\Field(type="int")
+     */
+    protected $position;
+
+    /**
+     * @Gedmo\SortableGroup
+     * @ODM\ReferenceOne(targetDocument="Sortable\Fixture\Document\Category")
+     */
+    protected $category;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setCategory(Category $category)
+    {
+        $this->category = $category;
+    }
+
+    public function getCategory()
+    {
+        return $this->category;
+    }
+}

--- a/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
+++ b/tests/Gedmo/Sortable/SortableDocumentGroupTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Gedmo\Sortable;
+
+use Tool\BaseTestCaseMongoODM;
+use Doctrine\Common\EventManager;
+use Sortable\Fixture\Document\Post;
+use Sortable\Fixture\Document\Category;
+use Sortable\Fixture\Document\Kid;
+
+/**
+ * These are tests for sortable behavior with SortableGroup
+ *
+ * @author http://github.com/vetalt
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class SortableDocumentGroupTest extends BaseTestCaseMongoODM
+{
+    const POST      = 'Sortable\\Fixture\\Document\\Post';
+    const CATEGORY  = 'Sortable\\Fixture\\Document\\Category';
+    const KID       = 'Sortable\\Fixture\\Document\\Kid';
+    const KID_DATE1 = '1999-12-31';
+    const KID_DATE2 = '2000-01-01';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SortableListener());
+
+        $this->getMockDocumentManager($evm);
+        $this->populate();
+    }
+
+    /**
+     * Insert 2 categories, 6 posts and 4 kids
+     * 3 posts are linked to a category, and 3 to the other one
+     * 2 kids have one date, 2 another one
+     */
+    private function populate()
+    {
+        $categories = array();
+        for ($i = 0; $i < 2; $i++) {
+            $categories[$i] = new Category();
+            $categories[$i]->setName('category'.$i);
+            $this->dm->persist($categories[$i]);
+        }
+
+        for ($i = 0; $i < 6; $i++) {
+            $post = new Post();
+            $post->setTitle('post'.$i);
+            $post->setCategory($categories[($i % 2)]);
+            $this->dm->persist($post);
+        }
+
+        $birthdates = array(
+            new \DateTime(self::KID_DATE1),
+            new \DateTime(self::KID_DATE2),
+            );
+        
+        for ($i = 0; $i < 4; $i++) {
+            $kid = new Kid();
+            $kid->setLastName('kid'.$i);
+            $kid->setBirthdate($birthdates[($i % 2)]);
+            $this->dm->persist($kid);
+        }
+        $this->dm->flush();
+        $this->dm->clear();
+    }
+
+    /**
+     * There should be 2 kids by position
+     */
+    public function testKidInitialPositions()
+    {
+        $repo = $this->dm->getRepository(self::KID);
+
+        for ($i = 0; $i < 2; $i++) {
+            $kids = $repo->findByPosition($i);
+            $this->assertCount(2, $kids);
+        }
+    }
+
+    /**
+     * Move the last kid in the first position
+     */
+    public function testKidMovePosition()
+    {
+        $repo = $this->dm->getRepository(self::KID);
+
+        $kid = $repo->findOneByLastname('kid2');
+        $this->assertInstanceOf(self::KID, $kid);
+
+        $kid->setPosition(0);
+        $this->dm->flush();
+
+        $kids = $repo->findByBirthdate(new \DateTime(self::KID_DATE1));
+        $this->assertCount(2, $kids);
+
+        for ($i=0; $i < 2; $i++) {
+            $expected = ($i+1 == 1) ? $i+1 : 0;
+            $this->assertEquals($expected, $kids[$i]->getPosition());
+        }
+    }
+
+    /**
+     * There should be 2 posts by position
+     */
+    public function testPostsInitialPositions()
+    {
+        $repo = $this->dm->getRepository(self::POST);
+
+        for ($i = 0; $i < 3; $i++) {
+            $posts = $repo->findByPosition($i);
+            $this->assertCount(2, $posts);
+        }
+    }
+
+    /**
+     * Move the last inserted post in first position and check
+     */
+    public function testPostsMovePosition()
+    {
+        $repo_category = $this->dm->getRepository(self::CATEGORY);
+        $repo_post = $this->dm->getRepository(self::POST);
+
+        $category = $repo_category->findOneByName('category1');
+        $this->assertInstanceOf(self::CATEGORY, $category);
+
+        $post = $repo_post->findOneBy(array(
+            'position' => 2,
+            'category.id' => $category->getId()
+        ));
+        $this->assertInstanceOf(self::POST, $post);
+
+        $post->setPosition(0);
+
+        $this->dm->flush();
+
+        $posts = $repo_post->findBy(array(
+            'category.id' => $category->getId()
+        ));
+        $this->assertCount(3, $posts);
+        
+        for ($i=0; $i < 3; $i++) {
+            $expected = ($i+1 < 3) ? $i+1 : 0;
+            $this->assertEquals($expected, $posts[$i]->getPosition());
+        }
+    }
+
+    /**
+     * Delete the 2nd post linked to a Category and check
+     */
+    public function testPostsDeletePosition()
+    {
+        $repo_category = $this->dm->getRepository(self::CATEGORY);
+        $repo_post = $this->dm->getRepository(self::POST);
+
+        $category = $repo_category->findOneByName('category1');
+        $this->assertInstanceOf(self::CATEGORY, $category);
+
+        $post = $repo_post->findOneBy(array(
+            'position' => 1,
+            'category.id' => $category->getId()
+        ));
+        $this->assertInstanceOf(self::POST, $post);
+
+        $this->dm->remove($post);
+        $this->dm->flush();
+
+        $posts = $repo_post->findBy(array(
+            'category.id' => $category->getId()
+        ));
+        $this->assertCount(2, $posts);
+        
+        for ($i=0; $i < 2; $i++) {
+            $this->assertEquals($i, $posts[$i]->getPosition());
+        }
+    }
+}


### PR DESCRIPTION
Question | Answer
-------- | ------
Bug fix ? | yes
New feature ? | no
BC breaks ? | no
Tests pass ? | yes

When we set SortableGroup on a referenced attribute like this : 
```php
/**
 * @Gedmo\SortableGroup
 * @ODM\ReferenceOne(targetDocument="Sortable\Fixture\Document\Category")
 */
protected $category;
```
an exception is thrown when we try to update the document.

This happens in ODM\Gedmo\Sortable\Mapping\Event\Adapter\ODM::getMaxPosition();
on the instruction
$document = $qb->getQuery()->getSingleResult();

    MongoException: zero-length keys are not allowed, did you use $ with double quotes?

I've add a condition in the querybuilder to handle the case of a sortable group based on a referenced document.

@stof, is !$dm->getMetadataFactory()->isTransient(ClassUtils::getClass($value)) the right way to test if an object is handle by Doctrine ?