### PR TITLE
Update tree.md

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -630,7 +630,7 @@ $controller = $this;
 
 ### Nesting Translatatable and Sluggable extensions
 
-If you want to attach **TranslationListener** also add it to EventManager after
+If you want to attach **TranslatableListener** also add it to EventManager after
 the **SluggableListener** and **TreeListener**. It is important because slug must be generated first
 before the creation of it`s translation.
 
@@ -641,7 +641,7 @@ $treeListener = new \Gedmo\Tree\TreeListener();
 $evm->addEventSubscriber($treeListener);
 $sluggableListener = new \Gedmo\Sluggable\SluggableListener();
 $evm->addEventSubscriber($sluggableListener);
-$translatableListener = new \Gedmo\Translatable\TranslationListener();
+$translatableListener = new \Gedmo\Translatable\TranslatableListener();
 $translatableListener->setTranslatableLocale('en_us');
 $evm->addEventSubscriber($translatableListener);
 // now this event manager should be passed to entity manager constructor


### PR DESCRIPTION
According to this commit: https://github.com/l3pp4rd/DoctrineExtensions/commit/7c5c8241ccf8d3a750961d489fe81e20aa0eb4b4

`TranslationListener` doesn't exist anymore. In documentation it still says `TranslationListener` which is confusing. Should be changed to `TranslatableListener`.