### PR TITLE
Fix the id strategy for closure and translation entities for PostgreSQL and Oracle

### DIFF
--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
@@ -16,7 +16,7 @@ abstract class AbstractPersonalTranslation
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
     protected $id;
 

--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
@@ -16,7 +16,7 @@ abstract class AbstractTranslation
      *
      * @ORM\Column(type="integer")
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
     protected $id;
 

--- a/lib/Gedmo/Tree/Entity/MappedSuperclass/AbstractClosure.php
+++ b/lib/Gedmo/Tree/Entity/MappedSuperclass/AbstractClosure.php
@@ -11,7 +11,7 @@ abstract class AbstractClosure
 {
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
     protected $id;


### PR DESCRIPTION
The Closure strategy and the translatable listener are inserting the data in SQL without providing the identifier, assuming it is generated by the database. However, the default id strategy for Doctrine is ``AUTO``, which chooses the strategy depending on the platform. When the sequence strategy is preferred (PostgreSQL and Oracle), these listeners were broken. Forcing the strategy to ``IDENTITY`` rather than ``AUTO`` fixes it.