### PR TITLE
Persistance of position relocations moved to other events to fix issue #1209

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -6,6 +6,7 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Doctrine\ORM\Proxy\Proxy;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
@@ -23,6 +24,7 @@ use Gedmo\Sortable\Mapping\Event\SortableAdapter;
 class SortableListener extends MappedEventSubscriber
 {
     private $relocations = array();
+    private $persistenceNeeded = false;
     private $maxPositions = array();
 
     /**
@@ -36,6 +38,10 @@ class SortableListener extends MappedEventSubscriber
             'onFlush',
             'loadClassMetadata',
             'prePersist',
+            'postPersist',
+            'preUpdate',
+            'preRemove',
+            'postFlush',
         );
     }
 
@@ -51,13 +57,21 @@ class SortableListener extends MappedEventSubscriber
     }
 
     /**
-     * Update position on objects being updated during flush
-     * if they require changing
+     * Collect position updates on objects being updated during flush
+     * if they require changing.
+     *
+     * Persisting of positions is done later during prePersist, preUpdate and preRemove
+     * events, otherwise the queries won't be executed within the transaction.
+     *
+     * The synchronization of the objects in memory is done in postFlush. This
+     * ensures that the positions have been successfully persisted to database.
      *
      * @param EventArgs $args
      */
     public function onFlush(EventArgs $args)
     {
+        $this->persistenceNeeded = true;
+
         $ea = $this->getEventAdapter($args);
         $om = $ea->getObjectManager();
         $uow = $om->getUnitOfWork();
@@ -85,7 +99,6 @@ class SortableListener extends MappedEventSubscriber
                 $this->processInsert($ea, $config, $meta, $object);
             }
         }
-        $this->processRelocations($ea);
     }
 
     /**
@@ -112,6 +125,27 @@ class SortableListener extends MappedEventSubscriber
                 $this->maxPositions[$hash] = $this->getMaxPosition($ea, $meta, $config, $object);
             }
         }
+    }
+
+    public function postPersist(EventArgs $args)
+    {
+        // persist position updates here, so that the update queries
+        // are executed within transaction
+        $this->persistRelocations($this->getEventAdapter($args));
+    }
+
+    public function preUpdate(EventArgs $args)
+    {
+        // persist position updates here, so that the update queries
+        // are executed within transaction
+        $this->persistRelocations($this->getEventAdapter($args));
+    }
+
+    public function preRemove(EventArgs $args)
+    {
+        // persist position updates here, so that the update queries
+        // are executed within transaction
+        $this->persistRelocations($this->getEventAdapter($args));
     }
 
     /**
@@ -157,7 +191,9 @@ class SortableListener extends MappedEventSubscriber
         $newPosition = min(array($this->maxPositions[$hash] + 1, $newPosition));
 
         // Compute relocations
-        $relocation = array($hash, $config['useObjectClass'], $groups, $newPosition, -1, +1);
+        // New inserted entities should not be relocated by position update, so we exclude it.
+        // Otherwise they could be relocated unintentionally.
+        $relocation = array($hash, $config['useObjectClass'], $groups, $newPosition, -1, +1, array($object));
 
         // Apply existing relocations
         $applyDelta = 0;
@@ -212,7 +248,7 @@ class SortableListener extends MappedEventSubscriber
         if ($changed) {
             $oldHash = $this->getHash($oldGroups, $config);
             $this->maxPositions[$oldHash] = $this->getMaxPosition($ea, $meta, $config, $object, $oldGroups);
-            $this->addRelocation($oldHash, $config['useObjectClass'], $oldGroups, $meta->getReflectionProperty($config['position'])->getValue($object) + 1, $this->maxPositions[$oldHash] + 1, -1, true);
+            $this->addRelocation($oldHash, $config['useObjectClass'], $oldGroups, $meta->getReflectionProperty($config['position'])->getValue($object) + 1, $this->maxPositions[$oldHash] + 1, -1);
         }
 
         if (array_key_exists($config['position'], $changeSet)) {
@@ -324,10 +360,15 @@ class SortableListener extends MappedEventSubscriber
     }
 
     /**
+     * Persists relocations to database.
      * @param SortableAdapter $ea
      */
-    private function processRelocations(SortableAdapter $ea)
+    private function persistRelocations(SortableAdapter $ea)
     {
+        if (!$this->persistenceNeeded) {
+            return;
+        }
+
         $em = $ea->getObjectManager();
         foreach ($this->relocations as $hash => $relocation) {
             $config = $this->getConfiguration($em, $relocation['name']);
@@ -336,6 +377,26 @@ class SortableListener extends MappedEventSubscriber
                     continue;
                 }
                 $ea->updatePositions($relocation, $delta, $config);
+            }
+        }
+
+        $this->persistenceNeeded = false;
+    }
+
+    /**
+     * Sync objects in memory
+     */
+    public function postFlush(PostFlushEventArgs $args)
+    {
+        $ea = $this->getEventAdapter($args);
+        $em = $ea->getObjectManager();
+        foreach ($this->relocations as $hash => $relocation) {
+            $config = $this->getConfiguration($em, $relocation['name']);
+            foreach ($relocation['deltas'] as $delta) {
+                if ($delta['start'] > $this->maxPositions[$hash] || $delta['delta'] == 0) {
+                    continue;
+                }
+
                 $meta = $em->getClassMetadata($relocation['name']);
 
                 // now walk through the unit of work in memory objects and sync those
@@ -376,11 +437,11 @@ class SortableListener extends MappedEventSubscriber
                     }
                 }
             }
-        }
 
-        // Clear relocations
-        $this->relocations = array();
-        $this->maxPositions = array();
+            // Clear relocations
+            unset($this->relocations[$hash]);
+            unset($this->maxPositions[$hash]); // unset only if relocations has been processed
+        }
     }
 
     private function getHash($groups, array $config)
@@ -437,24 +498,26 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Add a relocation rule
      *
-     * @param string $hash   The hash of the sorting group
-     * @param string $class  The object class
-     * @param array  $groups The sorting groups
-     * @param int    $start  Inclusive index to start relocation from
-     * @param int    $stop   Exclusive index to stop relocation at
-     * @param int    $delta  The delta to add to relocated nodes
+     * @param string $hash    The hash of the sorting group
+     * @param string $class   The object class
+     * @param array  $groups  The sorting groups
+     * @param int    $start   Inclusive index to start relocation from
+     * @param int    $stop    Exclusive index to stop relocation at
+     * @param int    $delta   The delta to add to relocated nodes
+     * @param array  $exclude Objects to be excluded from relocation
      */
-    private function addRelocation($hash, $class, $groups, $start, $stop, $delta)
+    private function addRelocation($hash, $class, $groups, $start, $stop, $delta, array $exclude = array())
     {
         if (!array_key_exists($hash, $this->relocations)) {
             $this->relocations[$hash] = array('name' => $class, 'groups' => $groups, 'deltas' => array());
         }
 
         try {
-            $newDelta = array('start' => $start, 'stop' => $stop, 'delta' => $delta);
+            $newDelta = array('start' => $start, 'stop' => $stop, 'delta' => $delta, 'exclude' => $exclude);
             array_walk($this->relocations[$hash]['deltas'], function (&$val, $idx, $needle) {
                 if ($val['start'] == $needle['start'] && $val['stop'] == $needle['stop']) {
                     $val['delta'] += $needle['delta'];
+                    $val['exclude'] = array_merge($val['exclude'], $needle['exclude']);
                     throw new \Exception("Found delta. No need to add it again.");
                 }
             }, $newDelta);

--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -6,7 +6,6 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\ORM\Event\PostFlushEventArgs;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Doctrine\ORM\Proxy\Proxy;
 use Gedmo\Sortable\Mapping\Event\SortableAdapter;
@@ -386,7 +385,7 @@ class SortableListener extends MappedEventSubscriber
     /**
      * Sync objects in memory
      */
-    public function postFlush(PostFlushEventArgs $args)
+    public function postFlush(EventArgs $args)
     {
         $ea = $this->getEventAdapter($args);
         $em = $ea->getObjectManager();

--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -40,7 +40,7 @@ class SortableListener extends MappedEventSubscriber
             'prePersist',
             'postPersist',
             'preUpdate',
-            'preRemove',
+            'postRemove',
             'postFlush',
         );
     }
@@ -60,7 +60,7 @@ class SortableListener extends MappedEventSubscriber
      * Collect position updates on objects being updated during flush
      * if they require changing.
      *
-     * Persisting of positions is done later during prePersist, preUpdate and preRemove
+     * Persisting of positions is done later during prePersist, preUpdate and postRemove
      * events, otherwise the queries won't be executed within the transaction.
      *
      * The synchronization of the objects in memory is done in postFlush. This
@@ -141,7 +141,7 @@ class SortableListener extends MappedEventSubscriber
         $this->persistRelocations($this->getEventAdapter($args));
     }
 
-    public function preRemove(EventArgs $args)
+    public function postRemove(EventArgs $args)
     {
         // persist position updates here, so that the update queries
         // are executed within transaction

--- a/tests/Gedmo/Sortable/Fixture/Customer.php
+++ b/tests/Gedmo/Sortable/Fixture/Customer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sortable\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sortable\Fixture\CustomerType;
+
+/**
+ * @ORM\Entity
+ */
+class Customer
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="name", type="string")
+     */
+    private $name;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="CustomerType", inversedBy="customers")
+     */
+    private $type;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType(CustomerType $type)
+    {
+        $this->type = $type;
+        if (!$type->getCustomers()->contains($this)) {
+            $type->addCustomer($this);
+        }
+    }
+}

--- a/tests/Gedmo/Sortable/Fixture/CustomerType.php
+++ b/tests/Gedmo/Sortable/Fixture/CustomerType.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Sortable\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Sortable\Entity\Repository\SortableRepository")
+ * @ORM\HasLifecycleCallbacks
+ */
+class CustomerType
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="name", type="string")
+     */
+    private $name;
+
+    /**
+     * @Gedmo\SortablePosition
+     * @ORM\Column(name="position", type="integer")
+     */
+    private $position;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Customer", mappedBy="type")
+     */
+    private $customers;
+
+    public function __construct()
+    {
+        $this->customers = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    public function getCustomers()
+    {
+        return $this->customers;
+    }
+
+    public function addCustomer(Customer $customer)
+    {
+        $this->customers->add($customer);
+    }
+
+    public function removeCustomer(Customer $customer)
+    {
+        $this->customers->removeElement($customer);
+    }
+
+    /**
+     * @ORM\PostRemove
+     */
+    public function postRemove()
+    {
+        if ($this->getCustomers()->count() > 0) {
+            // we imitate an foreign key constraint exception, because doctrine
+            // does not support sqlite constraints, which must be tested, too.
+            $pdoException = new \PDOException('SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails', "23000");
+            throw new ForeignKeyConstraintViolationException(sprintf('An exception occurred while deleting the customer type with id %s.', $this->getId()), new PDOException($pdoException));
+        }
+    }
+}

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Sortable;
 
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Tool\BaseTestCaseORM;
 use Sortable\Fixture\Node;
 use Sortable\Fixture\Item;
@@ -11,6 +12,8 @@ use Sortable\Fixture\SimpleListItem;
 use Sortable\Fixture\Author;
 use Sortable\Fixture\Paper;
 use Sortable\Fixture\Event;
+use Sortable\Fixture\Customer;
+use Sortable\Fixture\CustomerType;
 
 /**
  * These are tests for sortable behavior
@@ -28,6 +31,8 @@ class SortableTest extends BaseTestCaseORM
     const AUTHOR = 'Sortable\\Fixture\\Author';
     const PAPER = 'Sortable\\Fixture\\Paper';
     const EVENT = 'Sortable\\Fixture\\Event';
+    const CUSTOMER = 'Sortable\\Fixture\\Customer';
+    const CUSTOMER_TYPE = 'Sortable\\Fixture\\CustomerType';
 
     private $nodeId;
 
@@ -200,6 +205,51 @@ class SortableTest extends BaseTestCaseORM
 
         $this->assertEquals(0, $node1->getPosition());
         $this->assertEquals(1, $node3->getPosition());
+    }
+
+    /**
+     * This is a test case for issue #1209
+     * @test
+     */
+    public function shouldRollbackPositionAfterExceptionOnDelete()
+    {
+        $repo = $this->em->getRepository(self::CUSTOMER_TYPE);
+
+        $customerType1 = new CustomerType();
+        $customerType1->setName("CustomerType1");
+        $this->em->persist($customerType1);
+
+        $customerType2 = new CustomerType();
+        $customerType2->setName("CustomerType2");
+        $this->em->persist($customerType2);
+
+        $customerType3 = new CustomerType();
+        $customerType3->setName("CustomerType3");
+        $this->em->persist($customerType3);
+
+        $customer = new Customer();
+        $customer->setName("Customer");
+        $customer->setType($customerType2);
+        $this->em->persist($customer);
+
+        $this->em->flush();
+
+        try {
+            // now delete the second customer type, which should fail
+            // because of the foreign key reference
+            $this->em->remove($customerType2);
+            $this->em->flush();
+
+            $this->fail('Foreign key constraint violation exception not thrown.');
+        } catch (ForeignKeyConstraintViolationException $e) {
+            $customerTypes = $repo->findAll();
+
+            $this->assertCount(3, $customerTypes);
+
+            $this->assertEquals(0, $customerTypes[0]->getPosition(), 'The sorting position has not been rolled back.');
+            $this->assertEquals(1, $customerTypes[1]->getPosition(), 'The sorting position has not been rolled back.');
+            $this->assertEquals(2, $customerTypes[2]->getPosition(), 'The sorting position has not been rolled back.');
+        }
     }
 
     /**
@@ -551,6 +601,8 @@ class SortableTest extends BaseTestCaseORM
             self::AUTHOR,
             self::PAPER,
             self::EVENT,
+            self::CUSTOMER,
+            self::CUSTOMER_TYPE,
         );
     }
 

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -203,8 +203,16 @@ class SortableTest extends BaseTestCaseORM
         $this->em->remove($node2);
         $this->em->flush();
 
+        // test if synced on objects in memory correctly
         $this->assertEquals(0, $node1->getPosition());
         $this->assertEquals(1, $node3->getPosition());
+
+        // test if persisted correctly
+        $this->em->clear();
+        $nodes = $repo->findAll();
+        $this->assertCount(2, $nodes);
+        $this->assertEquals(0, $nodes[0]->getPosition());
+        $this->assertEquals(1, $nodes[1]->getPosition());
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue #1209. Please refer this issue to understand the background of this patch.

* I have added an unit test for issue #1209 
* Moved the persistance of position relocations from `onFlush` event, which is called before database transaction started, to the first call of `postPersist`, `preUpdate` or `preRemove`. So that the update query is executed within the transaction and if errors happen during queries the position changes will be rolled back.
* The synchronization of the objects has been separated from the database persistance, so that it will happen only if all queries were successfully executed (in `postFlush`).

The only thing I don't like with this solution is, that it will only work with entities that have identifiers. I am not sure if this is a problem.
I had to use these because the INSERTs are executed before the UPDATE query for the relocation of the positions. And that will manipulate the positions of inserted records. But I cannot use another event in this case.

Doctrine lacks an event which is fired between the beginning of a transaction and the inserts :-( This would have made the patch much simpler.