### PR TITLE
fix [Semantical Error] The class Entity is not annotated with @Annotatio...

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Translation.php
+++ b/lib/Gedmo/Translatable/Entity/Translation.php
@@ -2,24 +2,21 @@
 
 namespace Gedmo\Translatable\Entity;
 
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Index;
-use Doctrine\ORM\Mapping\UniqueConstraint;
-use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Gedmo\Translatable\Entity\Translation
  *
- * @Table(
+ * @ORM\Table(
  *         name="ext_translations",
- *         indexes={@Index(name="translations_lookup_idx", columns={
+ *         indexes={@ORM\Index(name="translations_lookup_idx", columns={
  *             "locale", "object_class", "foreign_key"
  *         })},
- *         uniqueConstraints={@UniqueConstraint(name="lookup_unique_idx", columns={
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
  *             "locale", "object_class", "field", "foreign_key"
  *         })}
  * )
- * @Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
+ * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */
 class Translation extends MappedSuperclass\AbstractTranslation
 {


### PR DESCRIPTION
...n. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of Entity. If it is indeed no annotation, then you need to add @IgnoreAnnotation(Entity) to the _class_ doc comment of class Gedmo\Translatable\Entity\Translation.
