### PR TITLE
Fix XML tree mapping to be used with resolving target entities.

### DIFF
--- a/lib/Gedmo/Tree/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Xml.php
@@ -164,7 +164,7 @@ class Xml extends BaseXml
                         $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
                         $targetEntity = $meta->associationMappings[$field]['targetEntity'];
                         $reflectionClass = new \ReflectionClass($targetEntity);
-                        if ($targetEntity != $meta->name && !$reflectionClass->isSubclassOf($meta->name)) {
+                        if ($targetEntity != $meta->name && !$reflectionClass->implementsInterface($meta->name)) {
                             throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
                         }
                         $config['parent'] = $field;


### PR DESCRIPTION
Similar to https://github.com/Atlantic18/DoctrineExtensions/pull/987 when using a target entity resolver it basically checks that (Acme\Model\Something)->isSubClassOf(Acme\Model\SomethingInterface) and was failing. 