### PR TITLE
Avoid persisting empty relations in the BlameableListener (fixes #1074 and #1226)

### DIFF
--- a/lib/Gedmo/Blameable/BlameableListener.php
+++ b/lib/Gedmo/Blameable/BlameableListener.php
@@ -83,7 +83,7 @@ class BlameableListener extends TimestampableListener
         $newValue = $this->getUserValue($meta, $field);
 
         //if blame is reference, persist object
-        if ($meta->hasAssociation($field)) {
+        if ($meta->hasAssociation($field) && $newValue) {
             $ea->getObjectManager()->persist($newValue);
         }
         $property->setValue($object, $newValue);

--- a/tests/Gedmo/Blameable/NoUserTest.php
+++ b/tests/Gedmo/Blameable/NoUserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Gedmo\Blameable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseMongoODM;
+use Blameable\Fixture\Document\Article;
+
+/**
+ * These are tests for Blameable behavior, when no user is available
+ *
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class NoUserTest extends BaseTestCaseMongoODM
+{
+    const ARTICLE = 'Blameable\Fixture\Document\Article';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $listener = new BlameableListener();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        // create the document manager
+        $this->getMockDocumentManager($evm);
+    }
+
+    public function testWhenNoUserIsAvailable()
+    {
+        $sport = new Article();
+        $sport->setTitle('sport no user');
+
+        $this->dm->persist($sport);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repo = $this->dm->getRepository(self::ARTICLE);
+        $sport = $repo->findOneByTitle('sport no user');
+        $this->assertEmpty($sport->getCreated());
+        $this->assertEmpty($sport->getUpdated());
+    }
+}


### PR DESCRIPTION
closes #1233 