### PR TITLE
TranslationWalker patch for postgresql explicit type casting problem

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -11,6 +11,8 @@ use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\Exec\SingleSelectExecutor;
 use Doctrine\ORM\Query\AST\RangeVariableDeclaration;
 use Doctrine\ORM\Query\AST\Join;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 
 /**
  * The translation sql output walker makes it possible
@@ -302,6 +304,7 @@ class TranslationWalker extends SqlWalker
             $transClass = $this->listener->getTranslationClass($ea, $meta->name);
             $transMeta = $em->getClassMetadata($transClass);
             $transTable = $transMeta->getQuotedTableName($this->platform);
+            $castFK = ($this->platform instanceof PostgreSqlPlatform) ? '::VARCHAR' : '';
             foreach ($config['fields'] as $field) {
                 $compTblAlias = $this->walkIdentificationVariable($dqlAlias, $field);
                 $tblAlias = $this->getSQLTableAlias('trans'.$compTblAlias.$field);
@@ -314,12 +317,12 @@ class TranslationWalker extends SqlWalker
                 $idColName = $meta->getQuotedColumnName($identifier, $this->platform);
                 if ($ea->usesPersonalTranslation($transClass)) {
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getSingleAssociationJoinColumnName('object')
-                        .' = '.$compTblAlias.'.'.$idColName;
+                        .' = '.$compTblAlias.'.'.$idColName.$castFK;
                 } else {
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('objectClass', $this->platform)
                         .' = '.$this->conn->quote($meta->name);
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform)
-                        .' = '.$compTblAlias.'.'.$idColName;
+                        .' = '.$compTblAlias.'.'.$idColName.$castFK;
                 }
                 isset($this->components[$dqlAlias]) ? $this->components[$dqlAlias] .= $sql : $this->components[$dqlAlias] = $sql;
 
@@ -328,9 +331,9 @@ class TranslationWalker extends SqlWalker
 
                 // Treat translation as original field type
                 $fieldMapping = $meta->getFieldMapping($field);
-                if ((($this->platform instanceof \Doctrine\DBAL\Platforms\MySqlPlatform) &&
+                if ((($this->platform instanceof MySqlPlatform) &&
                     in_array($fieldMapping["type"], array("decimal"))) ||
-                    (!($this->platform instanceof \Doctrine\DBAL\Platforms\MySqlPlatform) &&
+                    (!($this->platform instanceof MySqlPlatform) &&
                     !in_array($fieldMapping["type"], array("datetime", "datetimetz", "date", "time")))) {
                     $type = Type::getType($fieldMapping["type"]);
                     $substituteField = 'CAST('.$substituteField.' AS '.$type->getSQLDeclaration($fieldMapping, $this->platform).')';


### PR DESCRIPTION
This PR aims to fix type casting problem in `TranslationWalker` which consists only with PostgreSQL platform when using composite primary key on a `Translatable` entity.

**Problem:** Since `foreignKey` property of the [Translation](https://github.com/Atlantic18/DoctrineExtensions/blob/master/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php#L47) entity mapped as `string`, you can't use EQUAL operator (`=`) on this field if type of the both sides are not same. PostgreSQL is far more strict on type castings than MySQL. When you have a translatable entity with composite primary key, the final query which modified by TranslationWalker produces the error following:

> SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: character varying = integer LINE 1: ...lass = 'My\Entity' AND t1_.foreign_key = c0_.id O... ^ HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.

Note: Also some doctrine coding standards applied (see line 307 for actual addition) and all tests are passing. I don't add any test since i can't figure out how to run platform specific unit tests for this library. Also this PR solves same issue introduced in #1168 and #1176 but runs a little more performant since we don't need to check the platform while iterating every field.