### PR TITLE
Yaml mapping for references

### DIFF
--- a/lib/Gedmo/References/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/References/Mapping/Driver/Yaml.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Gedmo\References\Mapping\Driver;
+
+use Gedmo\Mapping\Driver\File;
+use Gedmo\Mapping\Driver;
+use Gedmo\Exception\InvalidMappingException;
+
+/**
+ * @author Gonzalo Vilaseca <gonzalo.vilaseca@reiss.com>
+ */
+class Yaml extends File implements Driver
+{
+    /**
+     * File extension
+     * @var string
+     */
+    protected $_extension = '.dcm.yml';
+
+    private $validReferences = array(
+        'referenceOne'       => array(),
+        'referenceMany'      => array(),
+        'referenceManyEmbed' => array(),
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function readExtendedMetadata($meta, array &$config)
+    {
+        $mapping = $this->_getMapping($meta->name);
+
+        if (isset($mapping['gedmo']) && isset($mapping['gedmo']['reference'])) {
+
+            foreach ($mapping['gedmo']['reference'] as $field => $fieldMapping) {
+                $reference = $fieldMapping['reference'];
+
+                if (!in_array($reference, array_keys($this->validReferences))) {
+                    throw new InvalidMappingException(
+                        $reference .
+                        ' is not a valid reference, valid references are: ' .
+                        implode(', ', array_keys($this->validReferences))
+                    );
+                }
+
+                $config[$reference][$field] = array(
+                    'field' => $field,
+                    'type'  => $fieldMapping['type'],
+                    'class' => $fieldMapping['class'],
+                );
+
+                if (array_key_exists('mappedBy', $fieldMapping)) {
+                    $config[$reference][$field]['mappedBy'] = $fieldMapping['mappedBy'];
+
+                }
+
+                if (array_key_exists('identifier', $fieldMapping)) {
+                    $config[$reference][$field]['identifier'] = $fieldMapping['identifier'];
+
+                }
+
+                if (array_key_exists('inversedBy', $fieldMapping)) {
+                    $config[$reference][$field]['inversedBy'] = $fieldMapping['inversedBy'];
+                }
+            }
+        }
+        $config = array_merge($this->validReferences, $config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _loadMappingFile($file)
+    {
+        return \Symfony\Component\Yaml\Yaml::parse($file);
+    }
+}


### PR DESCRIPTION
This adds yaml mapping to References extension, if it's ok I will update doc also, the yaml mapping would be like this:
```
gedmo:
    reference:   
        image:        
             reference: referenceOne
             type: document
             class: Document\Product
             inversedBy: stockItems
             identifier: productId
```
Being a relationship it might be worth validating that if it's the owning side it has ``inversedBy`` and ``              identifier`` defined? And if it's the inverse side it should have just ``mappedBy`` defined?