### PR TITLE
Use a LocaleResolver to select the default locale

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
@@ -82,8 +82,9 @@ class TranslationRepository extends EntityRepository
                 $transMeta->getReflectionProperty('field')->setValue($trans, $field);
                 $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
             }
-            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta) &&
-                $locale === $listener->getDefaultLocale()) {
+
+            $defaultLocale = $listener->getLocaleResolver()->getDefaultLocale($entity, $meta);
+            if ($defaultLocale != $listener->getTranslatableLocale($entity, $meta) && $locale === $defaultLocale) {
                 $listener->setTranslationInDefaultLocale(spl_object_hash($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();
             }

--- a/lib/Gedmo/Translatable/LocaleResolver.php
+++ b/lib/Gedmo/Translatable/LocaleResolver.php
@@ -1,0 +1,38 @@
+<?php
+namespace Gedmo\Translatable;
+
+/**
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class LocaleResolver implements LocaleResolverInterface
+{
+    /**
+     * Default locale, this changes behavior
+     * to not update the original record field if locale
+     * which is used for updating is not default. This
+     * will load the default translation in other locales
+     * if record is not translated yet
+     *
+     * @var string
+     */
+    private $defaultLocale = 'en_US';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultLocale($object = null, $meta = null)
+    {
+        return $this->defaultLocale;
+    }
+
+    /**
+     * Set the default locale.
+     *
+     * @param $locale
+     */
+    public function setDefaultLocale($locale)
+    {
+        $this->defaultLocale = $locale;
+    }
+}

--- a/lib/Gedmo/Translatable/LocaleResolverInterface.php
+++ b/lib/Gedmo/Translatable/LocaleResolverInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Gedmo\Translatable;
+
+/**
+ * @author Samuel ROZE <samuel.roze@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+interface LocaleResolverInterface
+{
+    /**
+     * Get the default locale.
+     *
+     * This default locale can change based on the object given in parameter.
+     *
+     * @param object|null $object
+     * @param object|null $meta
+     * @return string
+     */
+    public function getDefaultLocale($object = null, $meta = null);
+}

--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -184,11 +184,19 @@ class TranslatableListener extends MappedEventSubscriber
     }
 
     /**
-     * @param $localeResolver
+     * @param LocaleResolverInterface $localeResolver
      */
     public function setLocaleResolver($localeResolver)
     {
         $this->localeResolver = $localeResolver;
+    }
+
+    /**
+     * @return LocaleResolverInterface
+     */
+    public function getLocaleResolver()
+    {
+        return $this->localeResolver;
     }
 
     /**


### PR DESCRIPTION
Move the default locale logic inside a `LocaleResolver` class. This allow to override the default locale choice based on entities.

A usage can be to use a different default locale based on an entity field, which will improve performances if we know that a given entity will be used mostly for a given language while some other entities will be for another language.
