### PR TITLE
Fix translation handling when modifying documents

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -552,20 +552,28 @@ class TranslatableListener extends MappedEventSubscriber
                     break;
                 }
             }
+
             // lookup persisted translations
-            if ($ea->usesPersonalTranslation($translationClass)) {
-                foreach ($ea->getScheduledObjectInsertions($uow) as $trans) {
-                    $wasPersistedSeparetely = get_class($trans) === $translationClass
-                        && $trans->getLocale() === $locale
-                        && $trans->getField() === $field
-                        && $trans->getObject() === $object
-                    ;
-                    if ($wasPersistedSeparetely) {
-                        $translation = $trans;
-                        break;
-                    }
+            foreach ($ea->getScheduledObjectInsertions($uow) as $trans) {
+                if (get_class($trans) !== $translationClass
+                    || $trans->getLocale() !== $locale
+                    || $trans->getField() !== $field) {
+                    continue;
+                }
+
+                if ($ea->usesPersonalTranslation($translationClass)) {
+                    $wasPersistedSeparetely = $trans->getObject() === $object;
+                } else {
+                    $wasPersistedSeparetely = $trans->getObjectClass() === $config['useObjectClass']
+                        && $trans->getForeignKey() === $objectId;
+                }
+
+                if ($wasPersistedSeparetely) {
+                    $translation = $trans;
+                    break;
                 }
             }
+
             // check if translation already is created
             if (!$isInsert && !$translation) {
                 $translation = $ea->findTranslation(


### PR DESCRIPTION
Note: this issue is a side-effect of doctrine/mongodb-odm#999 and was found while hunting for that bug.

When handling an update for a translated object, the insertion queue of the ```UnitOfWork``` is only checked for duplicates if the object uses personal translations. This allows for duplicate key exceptions in rare cases. I think it's best to check for duplicate translation objects not only for personal translations but also for the built-in translation class.

Note 2: I've only managed to check and reproduce this issue when using the ODM, I'd appreciate it if somebody could check this against Doctrine ORM.