### PR TITLE
Added test for changing position of a record and insert a new one in front of it in one step

### DIFF
--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -370,6 +370,45 @@ class SortableTest extends BaseTestCaseORM
     /**
      * @test
      */
+    public function shouldInsertInbetween()
+    {
+        $this->markTestIncomplete('Currently it is not supported to change the position of a record and insert a new one in front of it in one step.');
+
+        $item1 = new Item();
+        $item1->setName("Item1");
+        $this->em->persist($item1);
+
+        $item3 = new Item();
+        $item3->setName("Item3");
+        $this->em->persist($item3);
+
+        $this->em->flush();
+
+        // update $item3's position
+        $item3->setPosition(2);
+
+        // and insert a further item between $item1 and $item3
+        $item2 = new Item();
+        $item2->setName("Item2");
+        $item2->setPosition(1);
+        $this->em->persist($item2);
+
+        $this->em->flush();
+
+        $repo = $this->em->getRepository(self::ITEM);
+        $items = $repo->findBy(array(), array('position' => 'asc'));
+
+        $this->assertEquals("Item1", $items[0]->getName());
+        $this->assertEquals(0, $items[0]->getPosition());
+        $this->assertEquals("Item2", $items[1]->getName());
+        $this->assertEquals(1, $items[1]->getPosition());
+        $this->assertEquals("Item3", $items[2]->getName());
+        $this->assertEquals(2, $items[2]->getPosition());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGroupByDateTimeValue()
     {
         $event1 = new Event();


### PR DESCRIPTION
The added should work, but it currently fails. This is why I have marked it as "incomplete".
The unit test shows that there is a bug. I couldn't find a solution, yet, but I think adding the test should be done anyway.

The problem is that during processing of the updates, the maximum position is `1`, so that the position of $item3 is set to `1`. Later, when the relocations are applied, the position of $item3 is not changed to `2` again, because it is already marked as _changed_.