### PR TITLE
Add the Sortable orderBy while creating a QueryBuilder

### DIFF
--- a/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
+++ b/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
@@ -70,7 +70,6 @@ class SortableRepository extends EntityRepository
         }
 
         $qb = $this->createQueryBuilder('n');
-        $qb->orderBy('n.'.$this->config['position']);
         $i = 1;
         foreach ($groupValues as $group => $value) {
             $qb->andWhere('n.'.$group.' = :group'.$i)
@@ -86,5 +85,14 @@ class SortableRepository extends EntityRepository
         $query = $this->getBySortableGroupsQuery($groupValues);
 
         return $query->getResult();
+    }
+
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        $qb = parent::createQueryBuilder($alias, $indexBy);
+
+        $qb->orderBy($alias.'.'.$this->config['position']);
+
+        return $qb;
     }
 }


### PR DESCRIPTION
Fixes #1179 by adding the `orderBy` while creating a QueryBuilder. The clause currently only is added if the `getBySortableGroupsQueryBuilder` from the repository is used.