### PR TITLE
Nested tree: fix empty condition when lft is zero

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -222,7 +222,7 @@ class NestedTreeRepository extends AbstractTreeRepository
                 } else {
                     $left = $wrapped->getPropertyValue($config['left']);
                     $right = $wrapped->getPropertyValue($config['right']);
-                    if ($left && $right) {
+                    if ($left !== NULL && $right) {
                         $qb
                             ->where($qb->expr()->lt('node.'.$config['right'], $right))
                             ->andWhere($qb->expr()->gt('node.'.$config['left'], $left))


### PR DESCRIPTION
I have a tree that doesn't have root node (or you could say there are multiple root nodes, but they all share the same lft/rgt ordering) and lft starts from zero. Manipulations with the tree seem to work fine, but I cannot get children for node with zero lft, because the query ends up with empty brackets and throws "expected literal" exception. This simple change should fix that.
