### PR TITLE
updated deprecated use of Yaml::parse

### DIFF
--- a/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
@@ -109,7 +109,7 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
     /**

--- a/lib/Gedmo/IpTraceable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/IpTraceable/Mapping/Driver/Yaml.php
@@ -107,7 +107,7 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
     /**

--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -101,6 +101,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }

--- a/lib/Gedmo/ReferenceIntegrity/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/ReferenceIntegrity/Mapping/Driver/Yaml.php
@@ -78,6 +78,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -123,7 +123,7 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
     /**

--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Yaml.php
@@ -63,6 +63,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }

--- a/lib/Gedmo/Sortable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Yaml.php
@@ -88,7 +88,7 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
     /**

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Yaml.php
@@ -83,7 +83,7 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
     /**

--- a/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
@@ -71,6 +71,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }

--- a/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
@@ -67,7 +67,7 @@ class Yaml extends File implements Driver
                 $config['closure'] = $class;
             }
         }
-        
+
         if (isset($mapping['id'])) {
             foreach($mapping['id'] as $field => $fieldMapping) {
                 if (isset($fieldMapping['gedmo'])) {
@@ -82,7 +82,7 @@ class Yaml extends File implements Driver
                 }
             }
         }
-        
+
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {
                 if (isset($fieldMapping['gedmo'])) {
@@ -204,6 +204,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }

--- a/lib/Gedmo/Uploadable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Uploadable/Mapping/Driver/Yaml.php
@@ -88,6 +88,6 @@ class Yaml extends File implements Driver
      */
     protected function _loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::parse($file);
+        return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 }


### PR DESCRIPTION
Per [Symfony documentation] (http://symfony.com/doc/current/components/yaml/introduction.html): "Passing a filename is deprecated in Symfony 2.2, and will be removed in Symfony 3.0."

Updated use:
`Yaml::parse(file_get_contents('/path/to/file.yml'));`