### PR TITLE
Bugfix #1333: Using doctrine/mongodb-odm with version 1.0.0-BETA13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/common": "~2.4"
     },
     "require-dev": {
-        "doctrine/mongodb-odm": ">=1.0.0-BETA13",
+        "doctrine/mongodb-odm": "1.0.0-BETA13",
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
         "symfony/yaml": "~2.6",


### PR DESCRIPTION
With version greater than 1.0.0-BETA13 the method "scheduleExtraUpdate" has been removed.