### PR TITLE
Fixing TranslationWalker.php which doesn't translate in a particular case

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -317,7 +317,7 @@ class TranslationWalker extends SqlWalker
                         .' = '.$compTblAlias.'.'.$idColName;
                 } else {
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('objectClass', $this->platform)
-                        .' = '.$this->conn->quote($meta->name);
+                        .' = '.$this->conn->quote($config['useObjectClass']);
                     $sql .= ' AND '.$tblAlias.'.'.$transMeta->getQuotedColumnName('foreignKey', $this->platform)
                         .' = '.$compTblAlias.'.'.$idColName;
                 }


### PR DESCRIPTION
closes #1334 

In the Class TranslationWalker, the method prepareTranslatedComponents() doesn't work correctly.
the line 327
.' = '.$this->conn->quote($meta->name);
should be replace by
.' = '.$this->conn->quote($config['useObjectClass']);

Because if you have a "CompanyBundle" having a class "Category" which own the translationMappedSuperclass\AbstractTranslation with the Class "CategoryTranslation".

And then have a "ClientBundle" which extends the class Category with a class ClientCategory (owning relations with more ClientBundle:Entities...).
if form the ClientCategory Repository i want to build some stuff using the:

$query->setHint(
\Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER,
'Gedmo\Translatable\Query\TreeWalker\TranslationWalker'
);

it will try to get the translation based on the entity name "ClientBundle\Entity\ClientCategory" and not "CompanyBundle\Entity\Category" as excpected in the field "object_class" of the translation table.

the result given is empty translated field (or the translated fallback).

this is why using $config['useObjectClass'] resolve this problem. As it give the real owner of the AbstractTranslation
