### PR TITLE
Allow locale to be retrieved from parent document

### DIFF
--- a/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
@@ -59,7 +59,7 @@ class TranslationRepository extends DocumentRepository
             throw new \Gedmo\Exception\InvalidArgumentException("Document: {$meta->name} does not translate field - {$field}");
         }
         $modRecordValue = (!$listener->getPersistDefaultLocaleTranslation() && $locale === $listener->getDefaultLocale())
-            || $listener->getTranslatableLocale($document, $meta) === $locale
+            || $listener->getTranslatableLocale($document, $meta, $this->getDocumentManager()) === $locale
         ;
         if ($modRecordValue) {
             $meta->getReflectionProperty($field)->setValue($document, $value);

--- a/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
@@ -61,7 +61,7 @@ class TranslationRepository extends EntityRepository
             throw new \Gedmo\Exception\InvalidArgumentException("Entity: {$meta->name} does not translate field - {$field}");
         }
         $needsPersist = true;
-        if ($locale === $listener->getTranslatableLocale($entity, $meta)) {
+        if ($locale === $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager())) {
             $meta->getReflectionProperty($field)->setValue($entity, $value);
             $this->_em->persist($entity);
         } else {
@@ -82,7 +82,7 @@ class TranslationRepository extends EntityRepository
                 $transMeta->getReflectionProperty('field')->setValue($trans, $field);
                 $transMeta->getReflectionProperty('locale')->setValue($trans, $locale);
             }
-            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta) &&
+            if ($listener->getDefaultLocale() != $listener->getTranslatableLocale($entity, $meta, $this->getEntityManager()) &&
                 $locale === $listener->getDefaultLocale()) {
                 $listener->setTranslationInDefaultLocale(spl_object_hash($entity), $field, $trans);
                 $needsPersist = $listener->getPersistDefaultLocaleTranslation();

--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -292,12 +292,13 @@ class TranslatableListener extends MappedEventSubscriber
      *
      * @param object $object
      * @param object $meta
+     * @param object $om
      *
      * @throws \Gedmo\Exception\RuntimeException - if language or locale property is not
      *                                           found in entity
      * @return string
      */
-    public function getTranslatableLocale($object, $meta, $om)
+    public function getTranslatableLocale($object, $meta, $om = null)
     {
         $locale = $this->locale;
         if (isset(self::$configurations[$this->name][$meta->name]['locale'])) {


### PR DESCRIPTION
Fixes #1304.

Note: This requires doctrine/mongodb-odm#1152 to be merged first.

This applies when using ODM because doctrine/mongodb-odm#782 WILL break translations in embedded documents. With this change it is possible to have the ```@Locale``` annotation in a root document and have that apply to ALL embedded documents within.