### PR TITLE
Nested Set Tree enhancements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ And especially ones who create and maintain new extensions:
 - Kudryashov Konstantin [everzet](http://github.com/everzet)
 - David Buchmann [dbu](https://github.com/dbu)
 
+.

--- a/README.md
+++ b/README.md
@@ -126,4 +126,3 @@ And especially ones who create and maintain new extensions:
 - Kudryashov Konstantin [everzet](http://github.com/everzet)
 - David Buchmann [dbu](https://github.com/dbu)
 
-.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gedmo/doctrine-extensions",
+    "name": "pmishev/doctrine-extensions",
     "type": "library",
     "description": "Doctrine2 behavioral extensions",
     "keywords": [

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -1257,7 +1257,7 @@ There are repository methods that are available for you in all the strategies:
       * nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
       * rootOpen: string || Closure ('\<ul\>') - branch start, closure will be given $children as a parameter
       * rootClose: string ('\</ul\>') - branch close
-      * childStart: string || Closure ('\<li\>') - start of node, closure will be given $node as a parameter
+      * childOpen: string || Closure ('\<li\>') - start of node, closure will be given $node as a parameter
       * childClose: string ('\</li\>') - close of node
       * childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
   - *includeNode*: Using "true", this argument allows you to include in the result the node you passed as the first argument. Defaults to "false".

--- a/lib/Gedmo/Mapping/Annotation/TreeLevel.php
+++ b/lib/Gedmo/Mapping/Annotation/TreeLevel.php
@@ -15,6 +15,10 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreeLevel extends Annotation
 {
-    /** @var integer */
+    /**
+     * The level which root nodes will have
+     *
+     * @var integer
+     */
     public $base = 0;
 }

--- a/lib/Gedmo/Mapping/Annotation/TreeLevel.php
+++ b/lib/Gedmo/Mapping/Annotation/TreeLevel.php
@@ -15,4 +15,6 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreeLevel extends Annotation
 {
+    /** @var integer */
+    public $base = 0;
 }

--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -298,12 +298,9 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!$sortByField) {
             $qb->orderBy('node.'.$config['left'], 'ASC');
         } elseif (is_array($sortByField)) {
-            $fields = '';
-            foreach ($sortByField as $field) {
-                $fields .= 'node.'.$field.',';
+            foreach ($sortByField as $key => $field) {
+                $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
             }
-            $fields = rtrim($fields, ',');
-            $qb->orderBy($fields, $direction);
         } else {
             if ($meta->hasField($sortByField) && in_array(strtolower($direction), array('asc', 'desc'))) {
                 $qb->orderBy('node.'.$sortByField, $direction);

--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -196,6 +196,27 @@ class NestedTreeRepository extends AbstractTreeRepository
     }
 
     /**
+     * Get the Tree path of Nodes by given $node as a string
+     *
+     * @param object $node
+     * @param string $separator
+     * @param string $stringMethod Entity method returning its displayable name.
+     *                             If not provided, entity must have __toString method
+     *
+     * @return string
+     */
+    public function getPathAsString($node, $separator = ' > ', $stringMethod = null)
+    {
+        $path = array();
+        $pathNodes = $this->getPath($node);
+        foreach ($pathNodes as $pathNode) {
+            $path[] = $stringMethod ? $pathNode->{$stringMethod}() : (string) $pathNode;
+        }
+
+        return implode($separator, $path);
+    }
+
+    /**
      * @see getChildrenQueryBuilder
      */
     public function childrenQueryBuilder($node = null, $direct = false, $sortByField = null, $direction = 'ASC', $includeNode = false)

--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -842,11 +842,11 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * Tries to recover the tree
      *
-     * @return void
+     * @param bool $verifyFirst Whether to verify the tree first, before attempting recovery
      */
-    public function recover()
+    public function recover($verifyFirst = true)
     {
-        if ($this->verify() === true) {
+        if ($verifyFirst && $this->verify() === true) {
             return;
         }
         $meta = $this->getClassMetadata();

--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -886,7 +886,9 @@ class NestedTreeRepository extends AbstractTreeRepository
      *
      * Tries to recover the tree
      *
-     * @param bool $verifyFirst Whether to verify the tree first, before attempting recovery
+     * @param bool   $verifyFirst Whether to verify the tree first, before attempting recovery
+     * @param string $sortByField Optional field to sort siblings by, while recovering
+     * @param string $direction   Direction for the sorting
      */
     public function recover($verifyFirst = true, $sortByField = null, $direction = 'ASC')
     {

--- a/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
@@ -162,7 +162,7 @@ class Annotation extends AbstractAnnotationDriver
                 $config['root'] = $field;
             }
             // level
-            if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::LEVEL)) {
+            if ($levelAnnotation = $this->reader->getPropertyAnnotation($property, self::LEVEL)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'level' - [{$field}] as mapped property in entity - {$meta->name}");
@@ -171,7 +171,7 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
                 }
                 $config['level'] = $field;
-                $config['level_base'] = (int) $pathAnnotation->base;
+                $config['level_base'] = (int) $levelAnnotation->base;
             }
             // path
             if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::PATH)) {

--- a/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
@@ -162,7 +162,7 @@ class Annotation extends AbstractAnnotationDriver
                 $config['root'] = $field;
             }
             // level
-            if ($this->reader->getPropertyAnnotation($property, self::LEVEL)) {
+            if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::LEVEL)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'level' - [{$field}] as mapped property in entity - {$meta->name}");
@@ -171,6 +171,7 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
                 }
                 $config['level'] = $field;
+                $config['level_base'] = (int) $pathAnnotation->base;
             }
             // path
             if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::PATH)) {

--- a/lib/Gedmo/Tree/RepositoryUtilsInterface.php
+++ b/lib/Gedmo/Tree/RepositoryUtilsInterface.php
@@ -18,7 +18,7 @@ interface RepositoryUtilsInterface
      *                             nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
      *                             rootOpen: string || Closure ('<ul>') - branch start, closure will be given $children as a parameter
      *                             rootClose: string ('</ul>') - branch close
-     *                             childStart: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
+     *                             childOpen: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
      *                             childClose: string ('</li>') - close of node
      *                             childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
      * @param boolean $includeNode - Include node on results?
@@ -41,7 +41,7 @@ interface RepositoryUtilsInterface
      *                       nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
      *                       rootOpen: string || Closure ('<ul>') - branch start, closure will be given $children as a parameter
      *                       rootClose: string ('</ul>') - branch close
-     *                       childStart: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
+     *                       childOpen: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
      *                       childClose: string ('</li>') - close of node
      *
      * @return array|string

--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -272,7 +272,7 @@ class Nested implements Strategy
     }
 
     /**
-     * Update the $node with a diferent $parent
+     * Update the $node with a different $parent
      * destination
      *
      * @param EntityManager $em
@@ -305,7 +305,7 @@ class Nested implements Strategy
         if (isset($this->nodePositions[$oid])) {
             $position = $this->nodePositions[$oid];
         }
-        $level = 0;
+        $level = isset($config['level_base']) ? $config['level_base'] : 0;
         $treeSize = $right - $left + 1;
         $newRootId = null;
         if ($parent) {


### PR DESCRIPTION
A number of enhancements for the nested set tree:

- Added 'base' property for tree level annotation
- Verify and recover wrong levels in nested set
- Added getPathAsString() method to entity repository
- Added option to recover tree, without verifying first
- Added option to reorder only direct children in reorder() method
- Added option to specify siblings order while recovering tree
- Fixed ordering in childrenQueryBuilder()
- Added and fixed some wrong comments