### PR TITLE
Fix #1058 : unique_base behavior dealing with relations

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Sluggable\Mapping\Event\Adapter;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Doctrine\ORM\Query;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
@@ -35,12 +36,24 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
 
         // use the unique_base to restrict the uniqueness check
         if ($config['unique'] && isset($config['unique_base'])) {
-            if (($ubase = $wrapped->getPropertyValue($config['unique_base'])) && !array_key_exists($config['unique_base'], $wrapped->getMetadata()->getAssociationMappings())) {
+            $ubase = $wrapped->getPropertyValue($config['unique_base']);
+            if (array_key_exists($config['unique_base'], $wrapped->getMetadata()->getAssociationMappings())) {
+                $mapping = $wrapped->getMetadata()->getAssociationMapping($config['unique_base']);
+            } else {
+                $mapping = false;
+            }
+            if ($ubase && !$mapping) {
                 $qb->andWhere('rec.'.$config['unique_base'].' = :unique_base');
                 $qb->setParameter(':unique_base', $ubase);
-            } elseif (array_key_exists($config['unique_base'], $wrapped->getMetadata()->getAssociationMappings())) {
-                $associationMappings = $wrapped->getMetadata()->getAssociationMappings();
-                $qb->join($associationMappings[$config['unique_base']]['targetEntity'], 'unique_'.$config['unique_base']);
+            } elseif ($ubase && $mapping && in_array($mapping['type'], array(ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::MANY_TO_ONE))) {
+                $mappedAlias = 'mapped_'.$config['unique_base'];
+                $wrappedUbase = AbstractWrapper::wrap($ubase, $em);
+                $qb->innerJoin('rec.'.$config['unique_base'], $mappedAlias);
+                foreach (array_keys($mapping['targetToSourceKeyColumns']) as $i => $mappedKey) {
+                    $mappedProp = $wrappedUbase->getMetadata()->fieldNames[$mappedKey];
+                    $qb->andWhere($qb->expr()->eq($mappedAlias.'.'.$mappedProp, ':assoc'.$i));
+                    $qb->setParameter(':assoc'.$i, $wrappedUbase->getPropertyValue($mappedProp));
+                }
             } else {
                 $qb->andWhere($qb->expr()->isNull('rec.'.$config['unique_base']));
             }

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/Page.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1058;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+class Page
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    protected $title;
+
+    /**
+     * @var User
+     *
+     * @ORM\ManyToOne(targetEntity="Sluggable\Fixture\Issue1058\User")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    protected $user;
+
+    /**
+     * @Gedmo\Slug(separator="-", fields={"title"}, unique=true, unique_base="user")
+     * @ORM\Column(name="slug", type="string", length=64)
+     */
+    protected $slug;
+
+    /**
+     * Getter of Id
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Setter of Slug
+     *
+     * @param string $slug
+     *
+     * @return $this
+     */
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    /**
+     * Getter of Slug
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+
+    /**
+     * Setter of Title
+     *
+     * @param string $title
+     *
+     * @return $this
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Getter of Title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return User
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param User $user
+     *
+     * @return $this
+     */
+    public function setUser(User $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Issue1058/User.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1058/User.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1058;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * Getter of Id
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1058Test.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Sluggable\Fixture\Issue1058\Page;
+use Sluggable\Fixture\Issue1058\User;
+
+/**
+ * These are tests for sluggable behavior
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class Issue1058Test extends BaseTestCaseORM
+{
+    const ARTICLE = 'Sluggable\\Fixture\\Issue1058\\Page';
+    const USER = 'Sluggable\\Fixture\\Issue1058\\User';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager;
+        $evm->addEventSubscriber(new SluggableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    /**
+     * @test
+     * @group issue1058
+     */
+    public function shouldHandleUniqueConstraintsBasedOnRelation()
+    {
+        $userFoo = new User();
+        $this->em->persist($userFoo);
+
+        $userBar = new User();
+        $this->em->persist($userBar);
+
+        $this->em->flush();
+
+        $page = new Page();
+        $page->setTitle('the title');
+        $page->setUser($userFoo);
+
+        $this->em->persist($page);
+        $this->em->flush();
+        $this->assertEquals('the-title', $page->getSlug());
+
+        $page = new Page();
+        $page->setTitle('the title');
+        $page->setUser($userBar);
+
+        $this->em->persist($page);
+        $this->em->flush();
+        $this->assertEquals('the-title', $page->getSlug());
+
+        $page = new Page();
+        $page->setTitle('the title');
+        $page->setUser($userBar);
+
+        $this->em->persist($page);
+        $this->em->flush();
+        $this->assertEquals('the-title-1', $page->getSlug());
+
+        $page = new Page();
+        $page->setTitle('the title');
+        $page->setUser($userFoo);
+
+        $this->em->persist($page);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertEquals('the-title-1', $page->getSlug());
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::ARTICLE,
+            self::USER
+        );
+    }
+}

--- a/tests/Gedmo/Sluggable/Issue/Issue827Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue827Test.php
@@ -158,6 +158,18 @@ class Issue827Test extends BaseTestCaseORM
 
         $this->assertEquals('post-2', $testPost2->getSlug());
 
+        // we have to refresh entities to ensure that Doctrine are aware of the sluggable generated identifiers
+        $this->em->clear();
+
+        $testPost1 = $this->em->find(
+            self::POST,
+            array('title' => $testPost1->getTitle(), 'slug' => $testPost1->getSlug())
+        );
+        $testPost2 = $this->em->find(
+            self::POST,
+            array('title' => $testPost2->getTitle(), 'slug' => $testPost2->getSlug())
+        );
+
         // Creating comments
 
         $test = new Comment();


### PR DESCRIPTION
Note: I had to update Issue827 tests: as discussed in #1349 using sluggable field as identifier leads to unexpected behavior when not reloading entities afterwards.