### PR TITLE
[Reference Entity] Add a new option "pull" to pull references before delete

### DIFF
--- a/lib/Gedmo/ReferenceIntegrity/Mapping/Validator.php
+++ b/lib/Gedmo/ReferenceIntegrity/Mapping/Validator.php
@@ -12,6 +12,7 @@ namespace Gedmo\ReferenceIntegrity\Mapping;
 class Validator
 {
     const NULLIFY = 'nullify';
+    const PULL = 'pull';
     const RESTRICT = 'restrict';
 
     /**
@@ -20,8 +21,9 @@ class Validator
      * @var array
      */
     private $integrityActions = array(
-        self::RESTRICT,
         self::NULLIFY,
+        self::PULL,
+        self::RESTRICT,
     );
 
     /**

--- a/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -97,7 +97,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
                         }
 
                         break;
-					case Validator::PULL:
+                    case Validator::PULL:
                         if (!isset($fieldMapping['mappedBy'])) {
                             throw new InvalidMappingException(
                                 sprintf(

--- a/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -120,7 +120,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
                             );
                         }
 
-                        if (!$meta->isCollectionValuedReference($fieldMapping['mappedBy'])) {
+                        if (!$subMeta->isCollectionValuedReference($fieldMapping['mappedBy'])) {
                             throw new InvalidMappingException(
                                 sprintf(
                                     "Reference integrity [%s] mapped property in entity - %s should be a Reference Many",

--- a/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -9,7 +9,7 @@ use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\ReferenceIntegrity\Mapping\Validator;
 
 /**
- * The ReferenceIntegrity listener handles the reference integrity on related entities
+ * The ReferenceIntegrity listener handles the reference integrity on related documents
  *
  * @author Evert Harmeling <evert.harmeling@freshheads.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -28,7 +28,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
     }
 
     /**
-     * Maps additional metadata for the Entity
+     * Maps additional metadata for the Document
      *
      * @param  EventArgs $eventArgs
      * @return void
@@ -87,12 +87,62 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
                         $refReflProp = $subMeta->getReflectionProperty($fieldMapping['mappedBy']);
 
                         if ($meta->isCollectionValuedReference($property)) {
-                            foreach ($refDoc as $object) {
-                                $refReflProp->setValue($object, null);
-                                $om->persist($object);
+                            foreach ($refDoc as $refObj) {
+                                $refReflProp->setValue($refObj, null);
+                                $om->persist($refObj);
                             }
                         } else {
                             $refReflProp->setValue($refDoc, null);
+                            $om->persist($refDoc);
+                        }
+
+                        break;
+					case Validator::PULL:
+                        if (!isset($fieldMapping['mappedBy'])) {
+                            throw new InvalidMappingException(
+                                sprintf(
+                                    "Reference '%s' on '%s' should have 'mappedBy' option defined",
+                                    $property,
+                                    $meta->name
+                                )
+                            );
+                        }
+
+                        $subMeta = $om->getClassMetadata($fieldMapping['targetDocument']);
+
+                        if (!$subMeta->hasField($fieldMapping['mappedBy'])) {
+                            throw new InvalidMappingException(
+                                sprintf(
+                                    "Unable to find reference integrity [%s] as mapped property in entity - %s",
+                                    $fieldMapping['mappedBy'],
+                                    $fieldMapping['targetDocument']
+                                )
+                            );
+                        }
+
+                        if (!$meta->isCollectionValuedReference($fieldMapping['mappedBy'])) {
+                            throw new InvalidMappingException(
+                                sprintf(
+                                    "Reference integrity [%s] mapped property in entity - %s should be a Reference Many",
+                                    $fieldMapping['mappedBy'],
+                                    $fieldMapping['targetDocument']
+                                )
+                            );
+                        }
+						
+                        $refReflProp = $subMeta->getReflectionProperty($fieldMapping['mappedBy']);
+
+                        if ($meta->isCollectionValuedReference($property)) {
+                            foreach ($refDoc as $refObj) {
+                                $collection = $refReflProp->getValue($refObj);
+                                $collection->removeElement($object);
+                                $refReflProp->setValue($refObj, $collection);
+                                $om->persist($refObj);
+                            }
+                        } else {
+                            $collection = $refReflProp->getValue($refDoc);
+                            $collection->removeElement($object);
+                            $refReflProp->setValue($refDoc, $collection);
                             $om->persist($refDoc);
                         }
 


### PR DESCRIPTION
Added a new option to the ReferenceIntegrity mapping to fix issue #1360  :

```
@Gedmo\ReferenceIntegrity("pull")
```
This option aims to remove ONLY the document which is removed from the Referenced documents collection on the owning side. (The nullify option sets the references collection on null).

+ renamed '$object' variable used twice.
+ replaced 'entity' anotations with 'document.

closes #1360 

Please review