### PR TITLE
Configure versioning without fields area in Entity yaml configuration

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -42,6 +42,14 @@ class Yaml extends File implements Driver
                     $config['logEntryClass'] = $cl;
                 }
             }
+
+            if (isset($classMapping['versioned'])) {
+                if (isset ($classMapping['versioned']['fields'])) {
+                    foreach ($classMapping['versioned']['fields'] as $field) {
+                        $config['versioned'][] = $field;
+                    }
+                }
+            }
         }
 
         if (isset($mapping['fields'])) {


### PR DESCRIPTION
Problem: https://github.com/FriendsOfSymfony/FOSUserBundle/issues/1357

using:
```yaml
UserBundle\Entity\User:
    type:  entity
    table: fos_user
    gedmo:
        loggable: true
        versioned:
            fields:
                - email
                - username
        soft_deleteable:
            field_name: deleted
            time_aware: false
    id:
        id:
            type: integer
            generator:
                strategy: AUTO
    fields:
        name:
          type: string
          length: 255
          nullable: true
          gedmo:
             - versioned
        created:
          type: datetime
          gedmo:
            timestampable:
              on: create
        updated:
          type: datetime
          gedmo:
            timestampable:
              on: update
        deleted:
            type: datetime
            nullable: true
```