### PR TITLE
Fix typo in Blameable documentation

### DIFF
--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -118,7 +118,7 @@ class Article
      * @var string $contentChangedBy
      *
      * @ORM\Column(name="content_changed_by", type="string", nullable=true)
-     * @Gedmo\Blameable(on="change", fields={"title", "body"})
+     * @Gedmo\Blameable(on="change", field={"title", "body"})
      */
     private $contentChangedBy;
 


### PR DESCRIPTION
The @Gedmo\Blameable property "fields" does not exist. The property is "field". That had me scratching my head for a while when following the docs, until I noticed it.