### PR TITLE
 - fixed centos file order for import

### DIFF
--- a/lib/Gedmo/Mapping/Annotation/All.php
+++ b/lib/Gedmo/Mapping/Annotation/All.php
@@ -7,8 +7,9 @@
 * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
-
-foreach (glob(__DIR__ . "/*.php") as $filename) {
+$files = glob(__DIR__ . "/*.php");
+asort($files);
+foreach ($files as $filename) {
     if (basename($filename, '.php') === 'All') {
         continue;
     }


### PR DESCRIPTION
ERROR: exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Cannot redeclare class Gedmo\Mapping
\Annotation\Reference' in /home/someuser/somewww/vendor/gedmo/doctrine-extensions/lib/Gedmo/Mapping/Annotation/Reference.php:22