### PR TITLE
Fixed version type casting in document repository to allow search in MongoDB

### DIFF
--- a/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
@@ -69,7 +69,7 @@ class LogEntryRepository extends DocumentRepository
         $qb = $this->createQueryBuilder();
         $qb->field('objectId')->equals($objectId);
         $qb->field('objectClass')->equals($objectMeta->name);
-        $qb->field('version')->lte($version);
+        $qb->field('version')->lte(intval($version));
         $qb->sort('version', 'ASC');
         $q = $qb->getQuery();
 


### PR DESCRIPTION
Changed version to always type cast to integer. Otherwise it's not possible to search for a revision to revert back to (when using MongoDB).

If the version is not type casted, no log entries will be found in the MongoDB database, since the MongoDB operation $lte doesn't allow strings for comparison.