### PR TITLE
Fix the incorrect fix for 'Cannot redeclare class Gedmo\Mapping\Annotation\Reference' error

### DIFF
--- a/lib/Gedmo/Mapping/Annotation/All.php
+++ b/lib/Gedmo/Mapping/Annotation/All.php
@@ -2,16 +2,13 @@
 
 /**
 * Contains all annotations for extensions
-* NOTE: should be included with require_once
 *
 * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
-$files = glob(__DIR__ . "/*.php");
-asort($files);
-foreach ($files as $filename) {
+foreach (glob(__DIR__ . "/*.php") as $filename) {
     if (basename($filename, '.php') === 'All') {
         continue;
     }
-    include $filename;
+    include_once $filename;
 }


### PR DESCRIPTION
The previous fix removes the 'Cannot redeclare class Gedmo\Mapping\Annotation\Reference'
error but does not fix the real bug. Sorting the list of files does not guarantee that
the same error will not show up again when new annotations are added. Instead, using an
include_once instead of include will not only prevent this bug happening again, but also
remove the requirement that the file must be loaded with require_once. This is useful
because the autoload/files section of composer.json loads files with require instead
of require_once. Adding this file to the composer.json of a library that uses
DoctrineExtensions will allow a developer to use that library without having to worry
about manually loading this file (since composer will include it in it's autoload).
