### PR TITLE
Fix Timestampable triggers php notice when trying to persist and flush embedded document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tests/phpunit.xml
 tests/temp/*.php
+tests/temp/*.log
 /vendor
 /bin
 /composer.lock

--- a/tests/Gedmo/Timestampable/Fixture/Document/Book.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Book.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Timestampable\Fixture\Document;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\Document(collection="books")
+ */
+class Book
+{
+    /**
+     * @ODM\Id()
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @ODM\String()
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @ODM\EmbedMany(targetDocument="Tag")
+     * @var Tag[]|Collection
+     */
+    protected $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+
+    /**
+     * @return Tag[]|Collection
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param Tag[] $tags
+     */
+    public function setTags(Collection $tags)
+    {
+        $this->tags = $tags;
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function addTag(Tag $tag)
+    {
+        $this->tags->add($tag);
+    }
+}

--- a/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Timestampable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\EmbeddedDocument()
+ */
+class Tag
+{
+    /**
+     * @ODM\String()
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @ODM\Date
+     * @Gedmo\Timestampable(on="create")
+     * @var \DateTime
+     */
+    protected $created;
+
+    /**
+     * @ODM\Date
+     * @Gedmo\Timestampable
+     * @var \DateTime
+     */
+    protected $updated;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * @param \DateTime $created
+     */
+    public function setCreated(\DateTime $created)
+    {
+        $this->created = $created;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * @param \DateTime $updated
+     */
+    public function setUpdated(\DateTime $updated)
+    {
+        $this->updated = $updated;
+    }
+}

--- a/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableEmbeddedDocumentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Gedmo\Timestampable;
+
+use Doctrine\Common\EventManager;
+use Timestampable\Fixture\Document\Book;
+use Timestampable\Fixture\Document\Tag;
+use Tool\BaseTestCaseMongoODM;
+
+/**
+ * These are tests for Timestampable behavior ODM implementation
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class TimestampableEmbeddedDocumentTest extends BaseTestCaseMongoODM
+{
+    const BOOK = 'Timestampable\Fixture\Document\Book';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TimestampableListener());
+
+        $this->getMockDocumentManager($evm);
+    }
+
+    /**
+     * Test that no php notice is triggered while processing timestampable properties of embedded document
+     */
+    public function testPersistOnlyEmbeddedDocument()
+    {
+        $tag = new Tag();
+        $tag->setName('cats');
+
+        $this->dm->persist($tag);
+        $this->dm->flush();
+        $this->dm->clear();
+    }
+
+    public function testPersistEmbeddedDocumentWithParent()
+    {
+        $tag1 = new Tag();
+        $tag1->setName('cats');
+
+        $tag2 = new Tag();
+        $tag2->setName('dogs');
+
+        $book = new Book();
+        $book->setTitle('Cats & Dogs');
+        $book->addTag($tag1);
+        $book->addTag($tag2);
+
+        $this->dm->persist($book);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repo = $this->dm->getRepository(self::BOOK);
+
+        $bookFromRepo = $repo->findOneByTitle('Cats & Dogs');
+
+        $this->assertNotNull($bookFromRepo);
+
+        $date = new \DateTime();
+
+        $this->assertEquals(
+            $date->format('Y-m-d H:i'),
+            $book->getTags()->get(0)->getCreated()->format('Y-m-d H:i')
+        );
+
+        $this->assertEquals(
+            $date->format('Y-m-d H:i'),
+            $book->getTags()->get(1)->getCreated()->format('Y-m-d H:i')
+        );
+
+        $this->assertEquals(
+            $date->format('Y-m-d H:i'),
+            $book->getTags()->get(0)->getUpdated()->format('Y-m-d H:i')
+        );
+
+        $this->assertEquals(
+            $date->format('Y-m-d H:i'),
+            $book->getTags()->get(1)->getUpdated()->format('Y-m-d H:i')
+        );
+    }
+}


### PR DESCRIPTION
Fix TimestampableListener triggers php notice when trying to persist and flush embedded document without parent document. Yes, it is uncommon case, but happens sometimes.
ODM unit of work says that such embedded documents are scheduled for insertion, but their change set actualy is empty and they are not flushed.