### PR TITLE
Fix CustomTransliteratorTest fail on Travis CI

### DIFF
--- a/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
+++ b/tests/Gedmo/Sluggable/CustomTransliteratorTest.php
@@ -28,7 +28,7 @@ class CustomTransliteratorTest extends BaseTestCaseORM
         $repo = $this->em->getRepository(self::ARTICLE);
 
         $chinese = $repo->findOneByCode('zh');
-        $this->assertEquals('zh', $chinese->getSlug());
+        $this->assertEquals('bei-jing-zh', $chinese->getSlug());
     }
 
     public function testCanUseCustomTransliterator()


### PR DESCRIPTION
Since transliteration map for Chinese language has changed in 1.1.0 version of  behat/transliteration library, i've changed the expected value in CustomTransliteratorTest.
This should make build green on Travis CI