### PR TITLE
[Translatable] Inconsistent result on inherited entity

### DIFF
--- a/tests/Gedmo/Translatable/Fixture/Issue/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Person.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Translatable\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\TranslationEntity(class="PersonTranslation")
+ */
+class Person
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Gedmo\Translatable
+     * @ORM\Column(name="name", type="string", length=128)
+     */
+    private $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Gedmo/Translatable/Fixture/Issue/Person.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Person.php
@@ -1,41 +1,84 @@
 <?php
 
-namespace Translatable\Fixture;
+namespace Translatable\Fixture\Issue;
 
 use Gedmo\Mapping\Annotation as Gedmo;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *      "staff" = "Staff",
+ *      "student" = "Student"
+ * })
  * @Gedmo\TranslationEntity(class="PersonTranslation")
  */
-class Person
+abstract class Person
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
-    private $id;
+    protected $id;
 
     /**
-     * @Gedmo\Translatable
+     * @var string
      * @ORM\Column(name="name", type="string", length=128)
      */
-    private $name;
+    protected $name;
 
+    protected $type;
+
+    /**
+     * @Gedmo\Locale
+     * Used locale to override Translation listener`s locale
+     * this is not a mapped field of entity metadata, just a simple property
+     */
+    protected $locale;
+
+    /**
+     * @ORM\OneToMany(
+     *      targetEntity="PersonTranslation",
+     *      mappedBy="object",
+     *      cascade={"persist", "remove"}
+     * )
+     */
+    protected $translations;
+
+    /**
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param $name
+     *
+     * @return $this
+     */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
+    }
+
+    public function setTranslatableLocale($locale)
+    {
+        $this->locale = $locale;
     }
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/PersonTranslation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Translatable\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
+
+/**
+ * @ORM\Table(
+ *         name="ext_translations",
+ *         indexes={@ORM\Index(name="translations_lookup_idx", columns={
+ *             "locale", "object_class", "foreign_key"
+ *         })},
+ *         uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
+ *             "locale", "object_class", "foreign_key", "field"
+ *         })}
+ * )
+ * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
+ */
+class PersonTranslation extends AbstractTranslation
+{
+}

--- a/tests/Gedmo/Translatable/Fixture/Issue/PersonTranslation.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/PersonTranslation.php
@@ -1,22 +1,36 @@
 <?php
 
-namespace Translatable\Fixture;
+namespace Translatable\Fixture\Issue;
 
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
 use Gedmo\Translatable\Entity\MappedSuperclass\AbstractTranslation;
 
 /**
- * @ORM\Table(
- *         name="ext_translations",
- *         indexes={@ORM\Index(name="translations_lookup_idx", columns={
- *             "locale", "object_class", "foreign_key"
- *         })},
- *         uniqueConstraints={@ORM\UniqueConstraint(name="lookup_unique_idx", columns={
- *             "locale", "object_class", "foreign_key", "field"
- *         })}
- * )
+ * @ORM\Table(name="person_translations", indexes={
+ *      @ORM\Index(name="person_translations_idx", columns={"locale", "field", "object_id"})
+ * })
  * @ORM\Entity(repositoryClass="Gedmo\Translatable\Entity\Repository\TranslationRepository")
  */
-class PersonTranslation extends AbstractTranslation
+class PersonTranslation extends AbstractPersonalTranslation
 {
+    /**
+     * @ORM\ManyToOne(targetEntity="Translatable\Fixture\Issue\Person", inversedBy="translations")
+     * @ORM\JoinColumn(name="object_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    protected $object;
+
+    /**
+     * Convenient constructor
+     *
+     * @param string $locale
+     * @param string $field
+     * @param string $value
+     */
+    public function __construct($locale, $field, $value)
+    {
+        $this->setLocale($locale);
+        $this->setField($field);
+        $this->setContent($value);
+    }
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue/Staff.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Staff.php
@@ -1,15 +1,43 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: adactive
- * Date: 08/10/15
- * Time: 14:06
- */
 
 namespace Translatable\Fixture\Issue;
 
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
 
-class Staff
+/**
+ * Class Staff
+ * @ORM\Entity
+ */
+class Staff extends Person
 {
+
+    /**
+     * @var string
+     * @Gedmo\Translatable
+     * @ORM\Column(name="role", type="string", length=128)
+     */
+    protected $role;
+
+    /**
+     * @return string
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * @param string $role
+     *
+     * @return $this
+     */
+    public function setRole($role)
+    {
+        $this->role = $role;
+
+        return $this;
+    }
+
 
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue/Staff.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Staff.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: adactive
+ * Date: 08/10/15
+ * Time: 14:06
+ */
+
+namespace Translatable\Fixture\Issue;
+
+
+class Staff
+{
+
+}

--- a/tests/Gedmo/Translatable/Fixture/Issue/Student.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Student.php
@@ -1,15 +1,42 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: adactive
- * Date: 08/10/15
- * Time: 14:01
- */
 
 namespace Translatable\Fixture\Issue;
 
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
 
-class Student
+/**
+ * Class Student
+ * @ORM\Entity
+ */
+class Student extends Person
 {
+    /**
+     * @var string
+     * @Gedmo\Translatable
+     * @ORM\Column(name="course", type="string", length=128)
+     */
+    protected $course;
+
+    /**
+     * @return string
+     */
+    public function getCourse()
+    {
+        return $this->course;
+    }
+
+    /**
+     * @param string $course
+     *
+     * @return $this
+     */
+    public function setCourse($course)
+    {
+        $this->course = $course;
+
+        return $this;
+    }
+
 
 }

--- a/tests/Gedmo/Translatable/Fixture/Issue/Student.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue/Student.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: adactive
+ * Date: 08/10/15
+ * Time: 14:01
+ */
+
+namespace Translatable\Fixture\Issue;
+
+
+class Student
+{
+
+}

--- a/tests/Gedmo/Translatable/Issue/IssueTest.php
+++ b/tests/Gedmo/Translatable/Issue/IssueTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Gedmo\Translatable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Doctrine\ORM\Query;
+use Gedmo\Translatable\Query\TreeWalker\TranslationWalker;
+use Translatable\Fixture\Article;
+use Translatable\Fixture\Comment;
+
+/**
+ * These are tests for translation query walker
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class Issue135Test extends BaseTestCaseORM
+{
+    const ARTICLE = 'Translatable\\Fixture\\Article';
+    const COMMENT = 'Translatable\\Fixture\\Comment';
+    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+
+    const TREE_WALKER_TRANSLATION = 'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker';
+
+    private $translatableListener;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $this->translatableListener = new TranslatableListener();
+        $this->translatableListener->setTranslatableLocale('en_us');
+        $this->translatableListener->setDefaultLocale('en_us');
+        $evm->addEventSubscriber($this->translatableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    public function testIssue135()
+    {
+        $query = $this->em->createQueryBuilder();
+        $query->select('a')
+            ->from(self::ARTICLE, 'a')
+            ->add('where', $query->expr()->not($query->expr()->eq('a.title', ':title')))
+            ->setParameter('title', 'NA')
+        ;
+
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setTranslationFallback(true);
+        $query = $query->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, self::TREE_WALKER_TRANSLATION);
+
+        $count = 0;
+        str_replace("locale = 'en'", '', $query->getSql(), $count);
+        $this->assertEquals(0, $count);
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::ARTICLE,
+            self::TRANSLATION,
+            self::COMMENT,
+        );
+    }
+
+    public function populate()
+    {
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setDefaultLocale('en');
+        $text0 = new Article();
+        $text0->setTitle('text0');
+
+        $this->em->persist($text0);
+
+        $text1 = new Article();
+        $text1->setTitle('text1');
+
+        $this->em->persist($text1);
+
+        $na = new Article();
+        $na->setTitle('NA');
+
+        $this->em->persist($na);
+
+        $out = new Article();
+        $out->setTitle('Out');
+
+        $this->em->persist($out);
+        $this->em->flush();
+        $this->translatableListener->setTranslatableLocale('es');
+
+        $text1->setTitle('texto1');
+        $text0->setTitle('texto0');
+        $this->em->persist($text1);
+        $this->em->persist($text0);
+        $this->em->flush();
+    }
+}


### PR DESCRIPTION
Hi,

I discover what I think is a bug but I am not able to fix it but I made some tests that reveals that bug. I hope someone will be able to complete my PR.

I have three entities:
- Person: an abstract entity that is translatable (in my test case there is no field translatable as it works fine)
- Staff & Student: both inherited from Person and add some translatable fields

I currently use the Query hint method to retrieve my entities in specific locale. The problem is when I query on the Person class which returns either Staff or Student, all Person fields are translated correctly but this is not the case for the subclass fields.

I found a work-around by switching listener translatable locale and not using query hint (see my test cases).

Finally while writing my unit tests, I found another issue which is if someone has already loaded an entity in some locale, the entity is in managed state on EntityManager. In that case requesting the same entity via EntityManager is not working and simply returns the entity used by this "someone".

Thank you,
Hoping this could help
