### PR TITLE
casting identifier to string since it is a varchar database field

### DIFF
--- a/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
@@ -81,7 +81,7 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
             }
         } else {
             // load translated content for all translatable fields
-            $objectId = $wrapped->getIdentifier();
+            $objectId = (string)$wrapped->getIdentifier();
             // construct query
             $dql = 'SELECT t.content, t.field FROM '.$translationClass.' t';
             $dql .= ' WHERE t.foreignKey = :objectId';


### PR DESCRIPTION
I have had some strange performance issues with the Translatable Behavior after having arount 1 million rows in ext_translations. Queries were dropping to around 300 - 400ms. Checking the Queries I found the following:

This query, generated by the behavior, is slow ( ~300ms ):
SELECT * FROM `ext_translations` WHERE `object_class` = 'Demo\\DemoBundle\\Entity\\Demo' AND `locale` = 'en' AND `foreign_key` = 111 

This query is fast ( ~1ms ):
SELECT * FROM `ext_translations` WHERE `object_class` = 'Demo\\DemoBundle\\Entity\\Demo' AND `locale` = 'en' AND `foreign_key` = '111'

There are two posibilities to "solve" this. Changing the the foreign_key column to integer did the same performance boost. But since ids can also be alphanumeric this is probably a bad idea to change globally. Casting the identifier to string seems to be no problem, since it is a varchar field anyways. Local tests only increased performance so far.

Thanks for discussing this change with me ( maybe there is a totally easy and obvious different solution to this issue :) ).

Regards,
Mario