### PR TITLE
Close #1415

### DIFF
--- a/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
+++ b/lib/Gedmo/Sortable/Entity/Repository/SortableRepository.php
@@ -70,6 +70,7 @@ class SortableRepository extends EntityRepository
         }
 
         $qb = $this->createQueryBuilder('n');
+        $qb->orderBy('n.'.$this->config['position']);
         $i = 1;
         foreach ($groupValues as $group => $value) {
             $qb->andWhere('n.'.$group.' = :group'.$i)
@@ -87,12 +88,4 @@ class SortableRepository extends EntityRepository
         return $query->getResult();
     }
 
-    public function createQueryBuilder($alias, $indexBy = null)
-    {
-        $qb = parent::createQueryBuilder($alias, $indexBy);
-
-        $qb->orderBy($alias.'.'.$this->config['position']);
-
-        return $qb;
-    }
 }


### PR DESCRIPTION
Revert cb95546bdcad2a86b8f152784cc307084472b4b6 commit, because SortableRepository causes an error with orderBy in createQueryBuilder.(for example by using select('COUNT(alias)') )  