### PR TITLE
 - fixed once and for all

### DIFF
--- a/lib/Gedmo/Mapping/Annotation/All.php
+++ b/lib/Gedmo/Mapping/Annotation/All.php
@@ -7,11 +7,9 @@
 * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
-$files = glob(__DIR__ . "/*.php");
-asort($files);
-foreach ($files as $filename) {
+foreach (glob(__DIR__ . "/*.php") as $filename) {
     if (basename($filename, '.php') === 'All') {
         continue;
     }
-    include $filename;
+    include_once $filename;
 }


### PR DESCRIPTION
I don't have time to investigate, but I get this error on any centos like distributive (i.e. Amazon Linux).

app/console c:c --env=prod
Fatal error: Cannot redeclare class Gedmo\Mapping\Annotation\Timestampable