### PR TITLE
Added citext field type to valid fields for sluggable

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -45,6 +45,7 @@ class Annotation extends AbstractAnnotationDriver
         'integer',
         'int',
         'datetime',
+        'citext',
     );
 
     /**

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -28,6 +28,7 @@ class Xml extends BaseXml
         'integer',
         'int',
         'datetime',
+        'citext',
     );
 
     /**

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -34,6 +34,7 @@ class Yaml extends File implements Driver
         'integer',
         'int',
         'datetime',
+        'citext',
     );
 
     /**


### PR DESCRIPTION
Hello,

I'm using postgresql and I'm trying to generate a slug for a case insensitive field (citext type). Is there another way to override mapping and allow citext as valid field type? Other that this pull request?