### PR TITLE
Making desactivation of soft deletable working

### DIFF
--- a/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
+++ b/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
@@ -55,6 +55,10 @@ class SoftDeleteableListener extends MappedEventSubscriber
         $uow = $om->getUnitOfWork();
         $evm = $om->getEventManager();
 
+        if (!$om->getFilters()->isEnabled('softdeleteable')) {
+            return;
+        }
+
         //getScheduledDocumentDeletions
         foreach ($ea->getScheduledObjectDeletions($uow) as $object) {
             $meta = $om->getClassMetadata(get_class($object));

--- a/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
+++ b/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
@@ -56,7 +56,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
         $uow = $om->getUnitOfWork();
         $evm = $om->getEventManager();
 
-        if ($om instanceof EntityManager && !$om->getFilters()->isEnabled('softdeleteable')) {
+        if ($om instanceof EntityManager && !$om->getFilters()->isEnabled('softdeleteable') && !$om->getFilters()->isEnabled('soft-deleteable')) {
             return;
         }
 

--- a/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
+++ b/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
@@ -5,6 +5,7 @@ namespace Gedmo\SoftDeleteable;
 use Gedmo\Mapping\MappedEventSubscriber;
 use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\UnitOfWork as MongoDBUnitOfWork;
+use Doctrine\ORM\EntityManager;
 
 /**
  * SoftDeleteable listener
@@ -55,7 +56,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
         $uow = $om->getUnitOfWork();
         $evm = $om->getEventManager();
 
-        if (!$om->getFilters()->isEnabled('softdeleteable')) {
+        if ($om instanceof EntityManager && !$om->getFilters()->isEnabled('softdeleteable')) {
             return;
         }
 


### PR DESCRIPTION
This patch make sure that the filter is enabled in the onFlush event before applying the behavior.

I experienced malfunction of this behavior, when I did something like that : 

```
    $em->getFilters()->disable('softdeleteable');
    $product = $em->getRepository('AppBundle:Product')->findOneBy(['idWorldwide' => 'XSWQAZ']);
    $em->remove($product);
    $em->flush();
```

It doesn't work the soft deletable behavior is still applied, this patch correct this.
