### PR TITLE
Use same object class name as metadata factory in repository. Fixes #1123

### DIFF
--- a/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Entity/Repository/TranslationRepository.php
@@ -117,12 +117,12 @@ class TranslationRepository extends EntityRepository
         $wrapped = new EntityWrapper($entity, $this->_em);
         if ($wrapped->hasValidIdentifier()) {
             $entityId = $wrapped->getIdentifier();
-            $entityClass = $wrapped->getMetadata()->rootEntityName;
-            $translationMeta = $this->getClassMetadata(); // table inheritance support
-
             $config = $this
                 ->getTranslatableListener()
                 ->getConfiguration($this->_em, get_class($entity));
+
+            $entityClass = isset($config['useObjectClass']) ? $config['useObjectClass'] : $wrapped->getMetadata()->rootEntityName;
+            $translationMeta = $this->getClassMetadata(); // table inheritance support
 
             $translationClass = isset($config['translationClass']) ?
                 $config['translationClass'] :

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/BaseEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Translatable\Fixture\Issue1123;
+
+use Gedmo\Translatable\Translatable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table("base_entity")
+ * @ORM\Inheritancetype("JOINED")
+ * @ORM\DiscriminatorColumn(name="discr", type="string")
+ * @ORM\DiscriminatorMap
+ * ({
+ * "base" = "BaseEntity",
+ * "child" = "ChildEntity"
+ * })
+ */
+abstract class BaseEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+
+}

--- a/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue1123/ChildEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Translatable\Fixture\Issue1123;
+
+use Gedmo\Translatable\Translatable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+use Translatable\Fixture\Issue1123\BaseEntity;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table("child_entity")
+ */
+class ChildEntity extends BaseEntity implements Translatable
+{
+    /**
+     * @Gedmo\Translatable
+     * @ORM\Column(name="childTitle", type="string", length=128, nullable=true)
+     */
+    private $childTitle;
+
+    /**
+     * @Gedmo\Locale
+     * Used locale to override Translation listener`s locale
+     * this is not a mapped field of entity metadata, just a simple property
+     */
+    private $locale = 'en';
+
+    public function getChildTitle() {
+        return $this->childTitle;
+    }
+
+    public function setChildTitle($childTitle) {
+        $this->childTitle = $childTitle;
+    }
+
+    public function setTranslatableLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+}

--- a/tests/Gedmo/Translatable/Issue/Issue1123Test.php
+++ b/tests/Gedmo/Translatable/Issue/Issue1123Test.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Gedmo\Translatable;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Translatable\Fixture\Issue922\Post;
+use Doctrine\ORM\Query;
+use Gedmo\Translatable\Query\TreeWalker\TranslationWalker;
+use Translatable\Fixture\Issue1123\BaseEntity;
+use Translatable\Fixture\Issue1123\ChildEntity;
+
+class Issue1123Test extends BaseTestCaseORM
+{
+    const TRANSLATION = 'Gedmo\\Translatable\\Entity\\Translation';
+    const BASE_ENTITY = 'Translatable\\Fixture\\Issue1123\\BaseEntity';
+    const CHILD_ENTITY = 'Translatable\\Fixture\\Issue1123\\ChildEntity';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $this->translatableListener = new TranslatableListener();
+        $this->translatableListener->setTranslatableLocale('en');
+        $this->translatableListener->setDefaultLocale('en');
+        $this->translatableListener->setTranslationFallback(true);
+        $evm->addEventSubscriber($this->translatableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFindInheritedClassTranslations()
+    {
+        $repo = $this->em->getRepository(self::TRANSLATION);
+
+        $title = 'Hello World';
+        $deTitle = 'Hallo Welt';
+
+        // Check that the child class can have translations
+        $childEntity = new ChildEntity();
+        $childEntity->setChildTitle($title);
+        $this->em->persist($childEntity);
+        $this->em->flush();
+
+        $childEntity->setTranslatableLocale('de');
+        $childEntity->setChildTitle($deTitle);
+        $this->em->persist($childEntity);
+        $this->em->flush();
+
+        // Clear to be sure...
+        $this->em->clear();
+
+        // Find using the repository
+        $translations = $repo->findTranslations($childEntity);
+        $this->assertCount(1, $translations);
+        $this->assertArraySubset(array('de' => array('childTitle' => $deTitle)), $translations);
+
+        // find using QueryBuilder
+        $qb = $this->em->createQueryBuilder()->select('e')->from(self::CHILD_ENTITY, 'e');
+
+        $query = $qb->getQuery();
+        $query->setHint(\Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER, 'Gedmo\Translatable\Query\TreeWalker\TranslationWalker');
+        $query->setHint(\Gedmo\Translatable\TranslatableListener::HINT_TRANSLATABLE_LOCALE, 'de');
+        $query->setHint(\Gedmo\Translatable\TranslatableListener::HINT_FALLBACK, 1);
+
+        $res = $query->getArrayResult();
+        $this->assertArraySubset(array('id' => 1, 'childTitle' => $deTitle, 'discr' => 'child'), $res[0]);
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::TRANSLATION,
+            self::BASE_ENTITY,
+            self::CHILD_ENTITY,
+        );
+    }
+}


### PR DESCRIPTION
closes #1123

This effectively changes 1 line to use `useObjectClass` from the translatable-listener configuration object for an entity that is part of an inheritance chain, and the base class does not have a translatable field.