### PR TITLE
[Tree] Ability to create relation to root node

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -149,7 +149,8 @@ class Category
 
     /**
      * @Gedmo\TreeRoot
-     * @ORM\Column(name="root", type="integer", nullable=true)
+     * @ORM\ManyToOne(targetEntity="Category")
+     * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
      */
     private $root;
 
@@ -181,6 +182,11 @@ class Category
         return $this->title;
     }
 
+    public function getRoot()
+    {
+        return $this->root;
+    }
+
     public function setParent(Category $parent = null)
     {
         $this->parent = $parent;
@@ -205,7 +211,7 @@ in the corresponding section).
 - **@Gedmo\Mapping\Annotation\TreeRight** field is used to store the tree **right** value
 - **@Gedmo\Mapping\Annotation\TreeParent** will identify the column as the relation to **parent node**
 - **@Gedmo\Mapping\Annotation\TreeLevel** field is used to store the tree **level**
-- **@Gedmo\Mapping\Annotation\TreeRoot** field is used to store the tree **root** id value
+- **@Gedmo\Mapping\Annotation\TreeRoot** field is used to store the tree **root** id value or identify the column as the relation to **root node**
 - **@Gedmo\Mapping\Annotation\TreePath** (Materialized Path only) field is used to store the **path**. It has an
 optional parameter "separator" to define the separator used in the path.
 - **@Gedmo\Mapping\Annotation\TreePathSource** (Materialized Path only) field is used as the source to
@@ -256,6 +262,14 @@ Entity\Category:
       gedmo:
         - treeLevel
   manyToOne:
+    root:
+      targetEntity: Entity\Category
+      joinColumn:
+        name: tree_root
+        referencedColumnName: id
+        onDelete: CASCADE
+      gedmo:
+        - treeRoot
     parent:
       targetEntity: Entity\Category
       inversedBy: children
@@ -305,6 +319,11 @@ Entity\Category:
         <field name="level" column="lvl" type="integer">
             <gedmo:tree-level/>
         </field>
+
+        <many-to-one field="root" target-entity="NestedTree">
+            <join-column name="tree_root" referenced-column-name="id" on-delete="CASCADE"/>
+            <gedmo:tree-root/>
+        </many-to-one>
 
         <many-to-one field="parent" target-entity="NestedTree" inversed-by="children">
             <join-column name="parent_id" referenced-column-name="id" on-delete="CASCADE"/>
@@ -728,6 +747,13 @@ class Category
     private $lvl;
 
     /**
+     * @Gedmo\TreeRoot
+     * @ORM\ManyToOne(targetEntity="Category")
+     * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     */
+    private $root;
+
+    /**
      * @Gedmo\TreeParent
      * @ORM\ManyToOne(targetEntity="Category", inversedBy="children")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
@@ -764,6 +790,11 @@ class Category
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function getRoot()
+    {
+        return $this->root;
     }
 
     public function setParent(Category $parent)
@@ -820,6 +851,14 @@ Entity\Category:
         - translatable
         - slug
   manyToOne:
+    root:
+      targetEntity: Entity\Category
+      joinColumn:
+        name: tree_root
+        referencedColumnName: id
+        onDelete: CASCADE
+      gedmo:
+        - treeRoot
     parent:
       targetEntity: Entity\Category
       inversedBy: children

--- a/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Annotation.php
@@ -152,13 +152,18 @@ class Annotation extends AbstractAnnotationDriver
             // root
             if ($this->reader->getPropertyAnnotation($property, self::ROOT)) {
                 $field = $property->getName();
-                if (!$meta->hasField($field)) {
-                    throw new InvalidMappingException("Unable to find 'root' - [{$field}] as mapped property in entity - {$meta->name}");
+                if (!$meta->isSingleValuedAssociation($field)) {
+                    if (!$meta->hasField($field)) {
+                        throw new InvalidMappingException("Unable to find 'root' - [{$field}] as mapped property in entity - {$meta->name}");
+                    }
+
+                    if (!$validator->isValidFieldForRoot($meta, $field)) {
+                        throw new InvalidMappingException(
+                            "Tree root field should be either a literal property ('integer' types or 'string') or a many-to-one association through root field - [{$field}] in class - {$meta->name}"
+                        );
+                    }
                 }
 
-                if (!$validator->isValidFieldForRoot($meta, $field)) {
-                    throw new InvalidMappingException("Tree root field - [{$field}] type is not valid and must be any of the 'integer' types or 'string' in class - {$meta->name}");
-                }
                 $config['root'] = $field;
             }
             // level

--- a/lib/Gedmo/Tree/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Xml.php
@@ -168,6 +168,14 @@ class Xml extends BaseXml
                         }
                         $config['parent'] = $field;
                     }
+                    if (isset($manyToOneMapping->{'tree-root'})) {
+                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
+                    }
                 }
             } elseif (isset($xmlDoctrine->{'reference-one'})) {
                 foreach ($xmlDoctrine->{'reference-one'} as $referenceOneMapping) {
@@ -182,6 +190,13 @@ class Xml extends BaseXml
                             throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
                         }
                         $config['parent'] = $field;
+                    }
+                    if (isset($referenceOneMapping->{'tree-root'})) {
+                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
                     }
                 }
             }
@@ -201,6 +216,14 @@ class Xml extends BaseXml
                         }
                         $config['parent'] = $field;
                     }
+                    if (isset($manyToOneMapping->{'tree-root'})) {
+                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
+                    }
                 }
             }
         } elseif ($xmlDoctrine->getName() == 'document') {
@@ -217,6 +240,13 @@ class Xml extends BaseXml
                             throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
                         }
                         $config['parent'] = $field;
+                    }
+                    if (isset($referenceOneMapping->{'tree-root'})) {
+                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
                     }
                 }
             }

--- a/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Yaml.php
@@ -182,6 +182,12 @@ class Yaml extends File implements Driver
                         }
                         $config['parent'] = $field;
                     }
+                    if (in_array('treeRoot', $relationMapping['gedmo'])) {
+                        if (!$rel = $this->getRelatedClassName($meta, $relationMapping['targetEntity'])) {
+                            throw new InvalidMappingException("Unable to find root-descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
+                    }
                 }
             }
         }

--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tree\Strategy\ORM;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Gedmo\Exception\UnexpectedValueException;
 use Doctrine\ORM\Proxy\Proxy;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -113,6 +114,7 @@ class Nested implements Strategy
      */
     public function processScheduledInsertion($em, $node, AdapterInterface $ea)
     {
+        /** @var ClassMetadata $meta */
         $meta = $em->getClassMetadata(get_class($node));
         $config = $this->listener->getConfiguration($em, $meta->name);
 
@@ -121,7 +123,7 @@ class Nested implements Strategy
         if (isset($config['level'])) {
             $meta->getReflectionProperty($config['level'])->setValue($node, 0);
         }
-        if (isset($config['root'])) {
+        if (isset($config['root']) && !$meta->hasAssociation($config['root'])) {
             $meta->getReflectionProperty($config['root'])->setValue($node, 0);
         }
     }
@@ -173,6 +175,7 @@ class Nested implements Strategy
     public function processPostPersist($em, $node, AdapterInterface $ea)
     {
         $meta = $em->getClassMetadata(get_class($node));
+
         $config = $this->listener->getConfiguration($em, $meta->name);
         $parent = $meta->getReflectionProperty($config['parent'])->getValue($node);
         $this->updateNode($em, $node, $parent, self::LAST_CHILD);

--- a/tests/Gedmo/Tree/Fixture/RootRelationCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootRelationCategory.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tree\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ * @Gedmo\Tree(type="nested")
+ */
+class RootRelationCategory
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\TreeLeft
+     * @ORM\Column(name="lft", type="integer")
+     */
+    private $lft;
+
+    /**
+     * @Gedmo\TreeRight
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    private $rgt;
+
+    /**
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="RootRelationCategory", inversedBy="children")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $parent;
+
+    /**
+     * @Gedmo\TreeRoot
+     * @ORM\ManyToOne(targetEntity="RootRelationCategory")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $root;
+
+    /**
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer")
+     */
+     private $level;
+
+    /**
+     * @ORM\OneToMany(targetEntity="RootRelationCategory", mappedBy="parent")
+     */
+    private $children;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setParent(RootRelationCategory $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function getRoot()
+    {
+        return $this->root;
+    }
+
+    public function getLeft()
+    {
+        return $this->lft;
+    }
+
+    public function getRight()
+    {
+        return $this->rgt;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+}

--- a/tests/Gedmo/Tree/NestedTreeRootRelationTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRelationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Gedmo\Tree;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Tree\Fixture\RootRelationCategory;
+
+/**
+ * These are tests for Tree behavior
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @link http://www.gediminasm.org
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class NestedTreeRootRelationTest extends BaseTestCaseORM
+{
+    const CATEGORY = "Tree\\Fixture\\RootRelationCategory";
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TreeListener());
+
+        $this->getMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    public function testRootEntity()
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+
+        // Foods
+        $food = $repo->findOneByTitle('Food');
+        $this->assertEquals($food->getId(), $food->getRoot()->getId());
+
+        $fruits = $repo->findOneByTitle('Fruits');
+        $this->assertEquals($food->getId(), $fruits->getRoot()->getId());
+
+        $vegetables = $repo->findOneByTitle('Vegetables');
+        $this->assertEquals($food->getId(), $vegetables->getRoot()->getId());
+
+        $carrots = $repo->findOneByTitle('Carrots');
+        $this->assertEquals($food->getId(), $carrots->getRoot()->getId());
+
+        $potatoes = $repo->findOneByTitle('Potatoes');
+        $this->assertEquals($food->getId(), $potatoes->getRoot()->getId());
+
+        // Sports
+        $sports = $repo->findOneByTitle('Sports');
+        $this->assertEquals($sports->getId(), $sports->getRoot()->getId());
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::CATEGORY,
+        );
+    }
+
+    private function populate()
+    {
+        $root = new RootRelationCategory();
+        $root->setTitle("Food");
+
+        $root2 = new RootRelationCategory();
+        $root2->setTitle("Sports");
+
+        $child = new RootRelationCategory();
+        $child->setTitle("Fruits");
+        $child->setParent($root);
+
+        $child2 = new RootRelationCategory();
+        $child2->setTitle("Vegetables");
+        $child2->setParent($root);
+
+        $childsChild = new RootRelationCategory();
+        $childsChild->setTitle("Carrots");
+        $childsChild->setParent($child2);
+
+        $potatoes = new RootRelationCategory();
+        $potatoes->setTitle("Potatoes");
+        $potatoes->setParent($child2);
+
+        $this->em->persist($root);
+        $this->em->persist($root2);
+        $this->em->persist($child);
+        $this->em->persist($child2);
+        $this->em->persist($childsChild);
+        $this->em->persist($potatoes);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}


### PR DESCRIPTION
I'm not sure if this is the right way, but in SyliusTaxonomyBundle we need to create a relation to root node.

```xml
<many-to-one field="root" target-entity="AppBundle\Entity\Taxon">
  <join-column name="tree_root" referenced-column-name="id" nullable="true" />
  <gedmo:tree-root />
</many-to-one>
```