### PR TITLE
#1006 drop null'ed translation

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -667,8 +667,7 @@ class TranslatableListener extends MappedEventSubscriber
                 // check if need to update in database
                 $transWrapper = AbstractWrapper::wrap($translation, $om);
                 if ($content === null && !$isInsert) {
-                    // if the $content is null'ed remove the full translation to avoid fragments
-                    $om->clear($translation);
+                    // if the $content is null'ed remove the translation to avoid fragments
                     $om->remove($translation);
                 } elseif ((is_bool($content) || is_int($content) || (is_string($content) && strlen($content) > 0) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
                     if ($isInsert && !$objectId && !$ea->usesPersonalTranslation($translationClass)) {

--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -666,7 +666,11 @@ class TranslatableListener extends MappedEventSubscriber
                 $translation->setContent($content);
                 // check if need to update in database
                 $transWrapper = AbstractWrapper::wrap($translation, $om);
-                if (((is_null($content) && !$isInsert) || is_bool($content) || is_int($content) || (is_string($content) && strlen($content) > 0) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
+                if ($content === null && !$isInsert) {
+                    // if the $content is null'ed remove the full translation to avoid fragments
+                    $om->clear($translation);
+                    $om->remove($translation);
+                } elseif ((is_bool($content) || is_int($content) || (is_string($content) && strlen($content) > 0) || !empty($content)) && ($isInsert || !$transWrapper->getIdentifier() || isset($changeSet[$field]))) {
                     if ($isInsert && !$objectId && !$ea->usesPersonalTranslation($translationClass)) {
                         // if we do not have the primary key yet available
                         // keep this translation in memory to insert it later with foreign key


### PR DESCRIPTION
Might require further testing (and require UnitTests).

Current state: hot-fixed null'ed translation for standard-storage type - including fallback-translation case.

Untested is the personal translation.

Likely to match all cases it would be best to abstract the removal to the adapter or maybe inject the removal at an earlier point of execution. The current approach however is minimal and does not touch fallback-translations behaviour.

May add a UnitTest in march (please remind me if needed).