### PR TITLE
handle content the same for ODM and ORM

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -508,7 +508,7 @@ class TranslatableListener extends MappedEventSubscriber
                 $translated = '';
                 foreach ((array) $result as $entry) {
                     if ($entry['field'] == $field) {
-                        $translated = $entry['content'];
+                        $translated = isset($entry['content']) ? $entry['content'] : null;
                         break;
                     }
                 }


### PR DESCRIPTION
Sorry to bother again regarding #1006.

I deeply analysed the differences in ODM and ORM behaviour on the `null` content and only found a single position where the key does not exist for ODM.

Thus a fix not effecting ORM-behaviour but avoiding the exception on ODM. Verified as sufficient for my use-case but to trivial to provide a unit-test.

Kindly asking you to consider this please on behalf of my customer..
