### PR TITLE
[v2.4.12] php5.3.2 not supported short array definition

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php
@@ -94,7 +94,7 @@ class MaterializedPathRepository extends AbstractTreeRepository
 
         $node = new EntityWrapper($node, $this->_em);
         $nodePath = $node->getPropertyValue($config['path']);
-        $paths = [];
+        $paths = array();
         $nodePathLength = strlen($nodePath);
         $separatorMatchOffset = 0;
         while ($separatorMatchOffset < $nodePathLength) {


### PR DESCRIPTION
In string [Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php#L97](https://github.com/Atlantic18/DoctrineExtensions/blob/2527d8f93779458e097447b5f92132bc65e672f4/lib/Gedmo/Tree/Entity/Repository/MaterializedPathRepository.php#L97) empty array defined as `[]` but `php5.3.2` not supports this syntax. But at the same time `php5.3.2` assigned as minimal supported version for `v2.4.12`