### PR TITLE
accept any phpunit release; don't require mock-objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
         "symfony/yaml": "~2.6",
-        "phpunit/phpunit": "~4.4",
-        "phpunit/phpunit-mock-objects": "~2.3"
+        "phpunit/phpunit": "*"
     },
     "suggest": {
         "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",


### PR DESCRIPTION
Hi guys..

Currently, we cannot switch to a recent `phpunit/phpunit` release because of the notation of `phpunit/phpunit-mock-objects` as a dependency in *this* repo blocks us.

**Important:** It is *not* necessary to specify `phpunit/phpunit-mock-objects` as a dependency as it's already a requirement of phpunit itself!
