### PR TITLE
Upgrading to symfony/yaml 3.0 (with backward-compatibility)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "doctrine/mongodb-odm": ">=1.0.2",
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
-        "symfony/yaml": "~2.6",
+        "symfony/yaml": "~2.6|~3.0",
         "phpunit/phpunit": "*"
     },
     "suggest": {

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml
@@ -31,11 +31,11 @@ Mapping\Fixture\Yaml\Category:
           fields:
             - title
           handlers:
-            "Gedmo\Sluggable\Handler\RelativeSlugHandler":
+            Gedmo\Sluggable\Handler\RelativeSlugHandler:
               relationField: parent
               relationSlugField: slug
               separator: /
-            "Gedmo\Sluggable\Handler\TreeSlugHandler":
+            Gedmo\Sluggable\Handler\TreeSlugHandler:
               parentRelationField: parent
               separator: /
     changed:


### PR DESCRIPTION
When added to the composer.json, symfony/symfony version 3.0, possibly a problem may occur.
To avoid this, I made some changes ... 

I did not do the tests, because the tests already exist.