### PR TITLE
Added blameable integer field support

### DIFF
--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -643,3 +643,36 @@ class UsingTrait
 The Traits are very simplistic - if you use different field names it is recommended to simply create your
 own Traits specific to your project. The ones provided by this bundle can be used as example.
 
+## ORM - ODM Hybrid databases
+
+You can use blameable with hybrid databases. If your user is an entity, but your blameable is a document, you can use
+an `int` field to store the user ID.
+
+```php
+/**
+ * @var int
+ *
+ * @Gedmo\Blameable(on="create")
+ * @ODM\Int()
+ */
+protected $createdById;
+```
+
+It also works well with the [references extension](references.md):
+
+```php
+/**
+ * @var User
+ *
+ * @Gedmo\ReferenceOne(type="entity", class=User::class, identifier="createdById")
+ */
+protected $createdBy;
+
+/**
+ * @var int
+ *
+ * @Gedmo\Blameable(on="create")
+ * @ODM\Int()
+ */
+protected $createdById;
+```

--- a/lib/Gedmo/Blameable/BlameableListener.php
+++ b/lib/Gedmo/Blameable/BlameableListener.php
@@ -59,12 +59,15 @@ class BlameableListener extends AbstractTrackingListener
         } elseif (in_array($meta->getTypeOfField($field), ['int', 'integer']) && !is_int($this->user)) {
             if (is_object($this->user)) {
                 if (method_exists($this->user, 'getId')) {
-                    return $this->user->getId();
+                    $id = $this->user->getId();
+                    if (is_int($id)) {
+                        return $id;
+                    }
                 }
             }
 
             throw new InvalidArgumentException(
-                "Field expects int, user must be an int, or object should have method getId"
+                "Field expects int, user must be an int, or object should have method getId, which returns an int."
             );
         }
 

--- a/lib/Gedmo/Blameable/BlameableListener.php
+++ b/lib/Gedmo/Blameable/BlameableListener.php
@@ -30,6 +30,10 @@ class BlameableListener extends AbstractTrackingListener
      */
     public function getFieldValue($meta, $field, $eventAdapter)
     {
+        if ($this->user === null) {
+            return null;
+        }
+
         if ($meta->hasAssociation($field)) {
             if (null !== $this->user && ! is_object($this->user)) {
                 throw new InvalidArgumentException("Blame is reference, user must be an object");
@@ -38,15 +42,30 @@ class BlameableListener extends AbstractTrackingListener
             return $this->user;
         }
 
-        // ok so its not an association, then it is a string
-        if (is_object($this->user)) {
-            if (method_exists($this->user, 'getUsername')) {
-                return (string) $this->user->getUsername();
+        if ($meta->getTypeOfField($field) === 'string' && !is_string($this->user)) {
+            if (is_object($this->user)) {
+                if (method_exists($this->user, 'getUsername')) {
+                    return (string) $this->user->getUsername();
+                }
+                if (method_exists($this->user, '__toString')) {
+                    return $this->user->__toString();
+                }
             }
-            if (method_exists($this->user, '__toString')) {
-                return $this->user->__toString();
+
+            throw new InvalidArgumentException(
+                "Field expects string, user must be a string, ".
+                "or object should have method getUsername or __toString"
+            );
+        } elseif (in_array($meta->getTypeOfField($field), ['int', 'integer']) && !is_int($this->user)) {
+            if (is_object($this->user)) {
+                if (method_exists($this->user, 'getId')) {
+                    return $this->user->getId();
+                }
             }
-            throw new InvalidArgumentException("Field expects string, user must be a string, or object should have method getUsername or __toString");
+
+            throw new InvalidArgumentException(
+                "Field expects int, user must be an int, or object should have method getId"
+            );
         }
 
         return $this->user;

--- a/lib/Gedmo/Blameable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Annotation.php
@@ -29,7 +29,8 @@ class Annotation extends AbstractAnnotationDriver
     protected $validTypes = array(
         'one',
         'string',
-        'int',
+        'int', // mongodb driver has both int and integer types
+        'integer',
     );
 
     /**

--- a/lib/Gedmo/Blameable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Xml.php
@@ -24,7 +24,8 @@ class Xml extends BaseXml
     private $validTypes = array(
         'one',
         'string',
-        'int',
+        'int', // mongodb driver has both int and integer types
+        'integer',
     );
 
     /**

--- a/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
@@ -31,7 +31,8 @@ class Yaml extends File implements Driver
     private $validTypes = array(
         'one',
         'string',
-        'int',
+        'int', // mongodb driver has both int and integer types
+        'integer',
     );
 
     /**

--- a/tests/Gedmo/Blameable/BlameableHybridTest.php
+++ b/tests/Gedmo/Blameable/BlameableHybridTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Gedmo\Blameable;
+
+use Blameable\Fixture\Document\Log;
+use Gedmo\Exception\InvalidArgumentException;
+use Tool\BaseTestCaseMongoODM;
+use Doctrine\Common\EventManager;
+use Blameable\Fixture\Model\User;
+
+/**
+ * These are tests for Blameable behavior in hybrid databases
+ *
+ * User is an entity, blameable is a document
+ *
+ * @see Gedmo\Blameable\BlameableHybridTest
+ */
+class BlameableHybridTest extends BaseTestCaseMongoODM
+{
+    const TEST_USERNAME = 'testuser';
+    const TEST_USERID = 1;
+
+    const LOG = 'Blameable\Fixture\Document\Log';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $user = new User();
+        $user->setId(self::TEST_USERID);
+        $user->setUsername(self::TEST_USERNAME);
+
+        $listener = new BlameableListener();
+        $listener->setUserValue($user);
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        $manager = $this->getMockDocumentManager($evm);
+
+        $this->populate();
+        $manager->flush();
+    }
+
+    public function testBlameable()
+    {
+        $repo = $this->dm->getRepository(self::LOG);
+        /** @var Log $log */
+        $log = $repo->findOneByContent('Some log info');
+
+        $this->assertEquals(self::TEST_USERNAME, $log->getCreated());
+        $this->assertEquals(self::TEST_USERID, $log->getUpdated());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Field expects int, user must be an int, or object should have method getId, which returns an int.
+     */
+    public function testBlameableNoGetId()
+    {
+        $listener = new BlameableListener();
+        $listener->setUserValue(new \stdClass());
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        $this->getMockDocumentManager($evm);
+
+        $this->populate();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Field expects int, user must be an int, or object should have method getId, which returns an int.
+     */
+    public function testBlameableGetIdNotInt()
+    {
+        $user = new User();
+        $user->setId('Not an int');
+        $user->setUsername(self::TEST_USERNAME);
+
+        $listener = new BlameableListener();
+        $listener->setUserValue($user);
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber($listener);
+
+        $this->getMockDocumentManager($evm);
+
+        $this->populate();
+    }
+
+    private function populate()
+    {
+        $log = new Log();
+        $log->setContent('Some log info');
+
+        $this->dm->persist($log);
+    }
+}

--- a/tests/Gedmo/Blameable/Fixture/Document/Log.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Log.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Blameable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * Does not follow the Article - Comment line by design
+ * Used to test hybrid database implementations
+ *
+ * @see Gedmo\Blameable\BlameableHybridTest
+ *
+ * @ODM\Document(collection="logs")
+ */
+class Log
+{
+    /** @ODM\Id */
+    private $id;
+
+    /**
+     * @ODM\String
+     */
+    private $content;
+
+    /**
+     * @var string $created
+     *
+     * @ODM\String
+     * @Gedmo\Blameable(on="create")
+     */
+    private $created;
+
+    /**
+     * @var int $updated
+     *
+     * @ODM\Int
+     * @Gedmo\Blameable
+     */
+    private $updated;
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param mixed $content
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * @param string $created
+     */
+    public function setCreated($created)
+    {
+        $this->created = $created;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * @param string $updated
+     */
+    public function setUpdated($updated)
+    {
+        $this->updated = $updated;
+    }
+}

--- a/tests/Gedmo/Blameable/Fixture/Model/User.php
+++ b/tests/Gedmo/Blameable/Fixture/Model/User.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Blameable\Fixture\Model;
+
+/**
+ * A POPO representation of a user, used in hybrid test, to avoid initializing both ORM and ODM sides
+ *
+ * @see Gedmo\Blameable\BlameableHybridTest
+ */
+class User
+{
+    private $id;
+    private $username;
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param mixed $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+}


### PR DESCRIPTION
- [x] Code
- [x] Tests
- [x] Docs

Related issue: #1137

Use case:
- User is an entity
- Comment is a document

Mapping: 
```php
    /**
     * @var int
     *
     * @Gedmo\Blameable(on="create")
     * @MongoDB\Int()
     */
    protected $createdById;
```

It works conviniently with references as well:

```php
    /**
     * @var User
     *
     * @Gedmo\ReferenceOne(type="entity", class=User::class, identifier="createdById")
     */
    protected $createdBy;

    /**
     * @var int
     *
     * @Gedmo\Blameable(on="create")
     * @MongoDB\Int()
     */
    protected $createdById;
```


**Will this be merged if I work on it?**