### PR TITLE
[Uploadable] UploadableFileName is not correct when used with appendNumber: true

### DIFF
--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberWithUploadableFileName.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileAppendNumberWithUploadableFileName.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Uploadable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Uploadable(appendNumber=true, pathMethod="getPath", callback="callbackMethod")
+ */
+class FileAppendNumberWithUploadableFileName
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", nullable=true)
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(name="path", type="string")
+     * @Gedmo\UploadableFileName
+     */
+    private $fileName;
+
+    public $callBackData = [];
+
+    public function callbackMethod($fileInfo)
+    {
+        $this->callBackData = $fileInfo;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setFileName($fileName)
+    {
+        $this->fileName = $fileName;
+    }
+
+    public function getFileName()
+    {
+        return $this->fileName;
+    }
+
+    public function getPath()
+    {
+        return __DIR__.'/../../../../temp/uploadable';
+    }
+}


### PR DESCRIPTION
Solving issue: [#1530](https://github.com/Atlantic18/DoctrineExtensions/issues/1530)

$info from **UploadableListener::moveFile** contains wrong data about file if used with appendNumber option.

Data before update:
```
$info['fileName'] == 'test.txt';
$info['fileWithoutExt'] == 'SOME/PATH/test';
$info['filePath'] == 'SOME/PATH/test-2.txt';
```

As you can see only filePath contains correct filename, when used with UploadableFileName annotation file is stored as SOME/PATH/test-2.txt in file system but as test.txt to database.
Same data are used for [callback option](https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/uploadable.md#uploadable-annotations)

I changed this information so they reflect correct generated filename like this:
```
$info['fileName'] == 'test-2.txt';
$info['fileWithoutExt'] == 'SOME/PATH/test-2';
$info['filePath'] == 'SOME/PATH/test-2.txt';
```
So data received by callback method and then returned from UploadableListener::moveFile contains correct info.

**This can be possible BC break but only if used with appendNumber option** but without it you cant use UploadableFileName mapping with appendNumber option.
