### PR TITLE
[Tree] Closure cannot handle different EntityManagers

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -170,7 +170,7 @@ class Closure implements Strategy
      */
     public function processPrePersist($em, $node)
     {
-        $this->pendingChildNodeInserts[spl_object_hash($node)] = $node;
+        $this->pendingChildNodeInserts[spl_object_hash($em)][spl_object_hash($node)] = $node;
     }
 
     /**
@@ -237,8 +237,9 @@ class Closure implements Strategy
     public function processPostPersist($em, $entity, AdapterInterface $ea)
     {
         $uow = $em->getUnitOfWork();
+        $emHash = spl_object_hash($em);
 
-        while ($node = array_shift($this->pendingChildNodeInserts)) {
+        while ($node = array_shift($this->pendingChildNodeInserts[$emHash])) {
             $meta = $em->getClassMetadata(get_class($node));
             $config = $this->listener->getConfiguration($em, $meta->name);
 
@@ -256,7 +257,7 @@ class Closure implements Strategy
 
             $referenceMapping = $em->getClassMetadata($config['closure'])->getAssociationMapping('ancestor');
             $referenceId = $referenceMapping['sourceToTargetKeyColumns'][$ancestorColumnName];
-            
+
             $entries = array(
                 array(
                     $ancestorColumnName => $nodeId,
@@ -348,7 +349,7 @@ class Closure implements Strategy
             $sql .= 'GROUP BY c.descendant';
 
             $levelsAssoc = $em->getConnection()->executeQuery($sql, array(array_keys($this->pendingNodesLevelProcess)), array($type))->fetchAll(\PDO::FETCH_NUM);
-            
+
             //create key pair array with resultset
             $levels = array();
             foreach( $levelsAssoc as $level )

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Tree;
 
 use Doctrine\Common\EventManager;
+use Gedmo\Tree\TreeListener;
 use Tool\BaseTestCaseORM;
 use Tree\Fixture\Closure\Category;
 use Tree\Fixture\Closure\News;
@@ -350,5 +351,33 @@ class ClosureTreeTest extends BaseTestCaseORM
                     ->getResult();
 
         $this->assertCount(1, $closure);
+    }
+
+    public function testPersistOnRightEmInstance()
+    {
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TreeListener());
+
+        $emOne = $this->getMockSqliteEntityManager($evm);
+        $emTwo = $this->getMockSqliteEntityManager($evm);
+
+        $uowOne = $emOne->getUnitOfWork();
+        $uowTwo = $emTwo->getUnitOfWork();
+
+        $politicsOne = new Category();
+        $politicsOne->setTitle('Politics');
+        $newsOne = new News('Lorem ipsum', $politicsOne);
+
+        $politicsTwo = new Category();
+        $politicsTwo->setTitle('Politics');
+        $newsTwo = new News('Lorem ipsum', $politicsTwo);
+
+        // Persist and Flush on different times !
+        $emOne->persist($newsOne);
+
+        $emTwo->persist($newsTwo);
+        $emTwo->flush();
+
+        $emOne->flush();
     }
 }

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -361,20 +361,21 @@ class ClosureTreeTest extends BaseTestCaseORM
         $emOne = $this->getMockSqliteEntityManager($evm);
         $emTwo = $this->getMockSqliteEntityManager($evm);
 
-        $politicsOne = new Category();
-        $politicsOne->setTitle('Politics');
-        $newsOne = new News('Lorem ipsum', $politicsOne);
+        $categoryOne = new Category();
+        $categoryOne->setTitle('Politics');
 
-        $politicsTwo = new Category();
-        $politicsTwo->setTitle('Politics');
-        $newsTwo = new News('Lorem ipsum', $politicsTwo);
+        $categoryTwo = new Category();
+        $categoryTwo->setTitle('Politics');
 
         // Persist and Flush on different times !
-        $emOne->persist($newsOne);
+        $emOne->persist($categoryOne);
 
-        $emTwo->persist($newsTwo);
+        $emTwo->persist($categoryTwo);
         $emTwo->flush();
 
         $emOne->flush();
+
+        $this->assertNotNull($categoryOne->getId());
+        $this->assertNotNull($categoryTwo->getId());
     }
 }

--- a/tests/Gedmo/Tree/ClosureTreeTest.php
+++ b/tests/Gedmo/Tree/ClosureTreeTest.php
@@ -361,9 +361,6 @@ class ClosureTreeTest extends BaseTestCaseORM
         $emOne = $this->getMockSqliteEntityManager($evm);
         $emTwo = $this->getMockSqliteEntityManager($evm);
 
-        $uowOne = $emOne->getUnitOfWork();
-        $uowTwo = $emTwo->getUnitOfWork();
-
         $politicsOne = new Category();
         $politicsOne->setTitle('Politics');
         $newsOne = new News('Lorem ipsum', $politicsOne);


### PR DESCRIPTION
Hi, I think the test is pretty self-explanatory about the bug.

The real use case is everywhere you work with multiple EntityManagers, like UnitTest, where the [EntityManager::create](https://github.com/doctrine/doctrine2/blob/v2.5.4/lib/Doctrine/ORM/EntityManager.php#L827) function is heavily used to ensure isolation between EntityManager instances with a good performance.

I don't know if the other 2 variables, [$pendingNodeUpdates](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.13/lib/Gedmo/Tree/Strategy/ORM/Closure.php#L49) and [$pendingNodesLevelProcess](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.13/lib/Gedmo/Tree/Strategy/ORM/Closure.php#L57) should need the same fix, but I was not able to create a test to find it out, so I prefered to leave them untouched.