### PR TITLE
Translatable: Fix PHP7 error "Cannot use 'String' as class name".

### DIFF
--- a/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractPersonalTranslation.php
@@ -21,7 +21,7 @@ abstract class AbstractPersonalTranslation
     /**
      * @var string $locale
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $locale;
 
@@ -34,14 +34,14 @@ abstract class AbstractPersonalTranslation
     /**
      * @var string $field
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $field;
 
     /**
      * @var string $content
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $content;
 

--- a/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Document/MappedSuperclass/AbstractTranslation.php
@@ -21,35 +21,35 @@ abstract class AbstractTranslation
     /**
      * @var string $locale
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $locale;
 
     /**
      * @var string $objectClass
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $objectClass;
 
     /**
      * @var string $field
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $field;
 
     /**
      * @var string $foreignKey
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $foreignKey;
 
     /**
      * @var string $content
      *
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     protected $content;
 


### PR DESCRIPTION
There is deprecate field type annotation in ODM in favor of Field.

Old:

    /**
    * @MongoODM\String
    */

New:

    /**
    * @MongoODM\Field(type="string")
    */