### PR TITLE
[SoftDelete] Use correct column name in MultiTableDeleteExecutor

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Gedmo/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
@@ -36,7 +36,7 @@ class MultiTableDeleteExecutor extends BaseMultiTableDeleteExecutor
 
             if (isset($matches[1]) && $meta->getQuotedTableName($platform) === $matches[1]) {
                 $sqlStatements[$index] = str_replace('DELETE FROM', 'UPDATE', $stmt);
-                $sqlStatements[$index] = str_replace('WHERE', 'SET '.$config['fieldName'].' = "'.date('Y-m-d H:i:s').'" WHERE', $sqlStatements[$index]);
+                $sqlStatements[$index] = str_replace('WHERE', 'SET '.$meta->fieldMappings[$config['fieldName']]['columnName'].' = "'.date('Y-m-d H:i:s').'" WHERE', $sqlStatements[$index]);
             } else {
                 // We have to avoid the removal of registers of child entities of a SoftDeleteable entity
                 unset($sqlStatements[$index]);


### PR DESCRIPTION
I've found an issue in `MultiTableDeleteExecutor` when there is a difference between field and columnName (column name in database) for example with a naming strategy underscore. 

This is because the field is being used instead of the column name. (https://github.com/Atlantic18/DoctrineExtensions/blob/8eae0903abfe8cfac2715018d807637bb92bbfc5/lib/Gedmo/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php#L39)

In detail:

```yml
doctrine:
    orm:
        naming_strategy: doctrine.orm.naming_strategy.underscore

Entity:
    type: entity
    gedmo:
        soft_deleteable:
            field_name: deletedAt
     fields:
     …
     deletedAt:
            type: datetime
            nullable: true
    inheritanceType: JOINED
    discriminatorColumn:
        name: type
```

Thanks!