### PR TITLE
Fix TimestampableDocument::getUpdatedAt return type

### DIFF
--- a/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
@@ -66,7 +66,7 @@ trait TimestampableDocument
     /**
      * Returns updatedAt.
      *
-     * @return \Datetime
+     * @return \DateTime
      */
     public function getUpdatedAt()
     {


### PR DESCRIPTION
Hi,

A small fix for a typo in the return type.

Regards,
Clément