### PR TITLE
Blameable yaml driver: Add support for mongodb odm association mapping

### DIFF
--- a/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Yaml.php
@@ -73,8 +73,9 @@ class Yaml extends File implements Driver
             }
         }
 
-        if (isset($mapping['manyToOne'])) {
-            foreach ($mapping['manyToOne'] as $field => $fieldMapping) {
+        if (isset($mapping['manyToOne']) || isset($mapping['referenceOne'])) {
+            $associationKey = isset($mapping['manyToOne']) ? 'manyToOne' : 'referenceOne'; // support orm or odm
+            foreach ($mapping[$associationKey] as $field => $fieldMapping) {
                 if (isset($fieldMapping['gedmo']['blameable'])) {
                     $mappingProperty = $fieldMapping['gedmo']['blameable'];
                     if (! $meta->isSingleValuedAssociation($field)) {


### PR DESCRIPTION
Current implementation does not work if using yml mapping files with mongodb since the driver is looking for `manyToOne` mapping information. In mongodb these are `referenceOne`. 