### PR TITLE
[Tree - Closure] Column name is used instead of field name

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -255,9 +255,6 @@ class Closure implements Strategy
             $descendantColumnName = $this->getJoinColumnFieldName($em->getClassMetadata($config['closure'])->getAssociationMapping('descendant'));
             $depthColumnName = $em->getClassMetadata($config['closure'])->getColumnName('depth');
 
-            $referenceMapping = $em->getClassMetadata($config['closure'])->getAssociationMapping('ancestor');
-            $referenceId = $referenceMapping['sourceToTargetKeyColumns'][$ancestorColumnName];
-
             $entries = array(
                 array(
                     $ancestorColumnName => $nodeId,
@@ -276,7 +273,7 @@ class Closure implements Strategy
 
                 foreach ($ancestors as $ancestor) {
                     $entries[] = array(
-                        $ancestorColumnName => $ancestor['ancestor'][$referenceId],
+                        $ancestorColumnName => $ancestor['ancestor'][$identifier],
                         $descendantColumnName => $nodeId,
                         $depthColumnName => $ancestor['depth'] + 1,
                     );


### PR DESCRIPTION
In `Gedmo\Tree\Strategy\ORM\Closure::processPostPersist`, colum name is used instead of field name:

 ```php
   public function processPostPersist($em, $entity, AdapterInterface $ea)
    {
        $uow = $em->getUnitOfWork();
        $emHash = spl_object_hash($em);

        while ($node = array_shift($this->pendingChildNodeInserts[$emHash])) {
            $meta = $em->getClassMetadata(get_class($node));
            $config = $this->listener->getConfiguration($em, $meta->name);

            //Get field name
            $identifier = $meta->getSingleIdentifierFieldName();

            //...

            $referenceMapping = $em->getClassMetadata($config['closure'])->getAssociationMapping('ancestor');
            //Get column name
            $referenceId = $referenceMapping['sourceToTargetKeyColumns'][$ancestorColumnName];

            //...
            if ($parent) {
                $dql = "SELECT c, a FROM {$closureMeta->name} c";
                $dql .= " JOIN c.ancestor a";
                $dql .= " WHERE c.descendant = :parent";
                $q = $em->createQuery($dql);
                $q->setParameters(compact('parent'));
                $ancestors = $q->getArrayResult();

                foreach ($ancestors as $ancestor) {
                    $entries[] = array(
                        //Doctrine returns field name (and not column name) but here the column name is used
                        $ancestorColumnName => $ancestor['ancestor'][$referenceId],
                        $descendantColumnName => $nodeId,
                        $depthColumnName => $ancestor['depth'] + 1,
                    );
                }
```

Example:
 ```php
namespace AppBundle\Entity\Indexation;

use Doctrine\ORM\Mapping as ORM;
use Gedmo\Mapping\Annotation as Gedmo;
use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @ORM\Entity()
 * @ORM\Table(name="event")
 * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\ClosureTreeRepository")
 * @UniqueEntity(fields={"name"})
 * @Gedmo\Tree(type="closure")
 * @Gedmo\TreeClosure(class="AppBundle\Entity\Indexation\EventClosure")
 */
class Event extends AbstractTreeIndexation
{
    /**
     * @ORM\Id
     * @ORM\Column(type="integer", name="event_id")
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    protected $eventId;

    /**
     * @ORM\Column(type="string", length=100, unique=true)
     * @Assert\Length(max=100)
     * @Assert\NotBlank()
     */
    protected $name;

    /**
     * @ORM\Column(name="level", type="integer", nullable=true)
     * @Gedmo\TreeLevel
     */
    protected $level;

    /**
     * @Gedmo\TreeParent
     * @ORM\JoinColumn(name="parent_id", referencedColumnName="event_id", onDelete="CASCADE")
     * @ORM\ManyToOne(targetEntity="Event")
     */
    protected $parent;
```
* eventId is field name
* event_id is column name

 ```php
namespace AppBundle\Entity\Indexation;

use Doctrine\ORM\Mapping as ORM;
use Gedmo\Tree\Entity\MappedSuperclass\AbstractClosure;

/**
 * @ORM\Entity
 */
class EventClosure extends AbstractClosure
{
    /**
     * @ORM\JoinColumn(name="ancestor", referencedColumnName="event_id", onDelete="CASCADE", nullable=false)
     * @ORM\ManyToOne(targetEntity="Event")
     */
    protected $ancestor;

    /**
     * @ORM\JoinColumn(name="descendant", referencedColumnName="event_id", onDelete="CASCADE", nullable=false)
     * @ORM\ManyToOne(targetEntity="Event")
     */
    protected $descendant;
```

When processPostPersist is called, this error is thrown:

> Notice: Undefined index: event_id in vendor/gedmo/doctrine-extensions/lib/Gedmo/Tree/Strategy/ORM/Closure.php at line 279