### PR TITLE
Fix 1605

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -434,10 +434,12 @@ class SluggableListener extends MappedEventSubscriber
         // collect similar persisted slugs during this flush
         if (isset($this->persisted[$class = $ea->getRootObjectClass($meta)])) {
             foreach ($this->persisted[$class] as $obj) {
-                if ($base !== false && $meta->getReflectionProperty($config['unique_base'])->getValue($obj) !== $base) {
+                $similarMeta = $om->getClassMetadata(get_class($obj));
+                if ($base !== false && $similarMeta->getReflectionProperty($config['unique_base'])->getValue($obj) !== $base) {
                     continue; // if unique_base field is not the same, do not take slug as similar
                 }
-                $slug = $meta->getReflectionProperty($config['slug'])->getValue($obj);
+                $slugRefl = $similarMeta->getReflectionProperty($config['slug']);
+                $slug = $slugRefl->getValue($obj);
                 $quotedPreferredSlug = preg_quote($preferredSlug);
                 if (preg_match("@^{$quotedPreferredSlug}.*@smi", $slug)) {
                     $similarPersisted[] = array($config['slug'] => $slug);

--- a/tests/Gedmo/Sluggable/Fixture/Issue1605/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1605/Article.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1605;
+
+use Gedmo\Sluggable\Sluggable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Article extends ParentEntity implements Sluggable
+{
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\Slug(fields={"title"})
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    private $slug;
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Issue1605/Page.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1605/Page.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Sluggable\Fixture\Issue1605;
+
+use Gedmo\Sluggable\Sluggable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Page extends ParentEntity implements Sluggable
+{
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\Slug(fields={"title"})
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    private $slug;
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+}

--- a/tests/Gedmo/Sluggable/Fixture/Issue1605/ParentEntity.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1605/ParentEntity.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Sluggable\Fixture\Issue1605;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType(value="JOINED")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *      "page" = "Page",
+ *      "article" = "Article"
+ * })
+ */
+abstract class ParentEntity
+{
+    /**
+     * @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Gedmo/Sluggable/Issue/Issue1605Test.php
+++ b/tests/Gedmo/Sluggable/Issue/Issue1605Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Sluggable\Fixture\Issue1605\Article;
+use Sluggable\Fixture\Issue1605\Page;
+use Tool\BaseTestCaseORM;
+
+class Issue1605Test extends BaseTestCaseORM
+{
+    const PARENT  = 'Sluggable\\Fixture\\Issue1605\\ParentEntity';
+    const ARTICLE = 'Sluggable\\Fixture\\Issue1605\\Article';
+    const PAGE    = 'Sluggable\\Fixture\\Issue1605\\Page';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager;
+        $evm->addEventSubscriber(new SluggableListener);
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::PARENT,
+            self::ARTICLE,
+            self::PAGE,
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotFailWithJoinedInheritanceAndMultipleEntitiesWithSameSlugPropertyOnPHP707()
+    {
+        $article = new Article();
+        $article->setTitle('the title');
+        $this->em->persist($article);
+
+        $page = new Page();
+        $page->setTitle('the title');
+        $this->em->persist($page);
+
+        $this->em->flush();
+    }
+}


### PR DESCRIPTION
This PR fixes #1605.

As explained by the test, the bug is reproduced by having two different entities using joined inheritance and both map the slug under the same property (but not inheriting it).
