### PR TITLE
Support for versioning of @EmbedMany ODM relations

### DIFF
--- a/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
@@ -44,10 +44,10 @@ class LogEntryRepository extends DocumentRepository
         $qb->field('objectId')->equals($objectId);
         $qb->field('objectClass')->equals($wrapped->getMetadata()->name);
         $qb->sort('version', 'DESC');
-        if($limit) {
+        if ($limit) {
             $qb->limit($limit);
         }
-        if($skip) {
+        if ($skip) {
             $qb->skip($skip);
         }
         $q = $qb->getQuery();

--- a/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
@@ -84,7 +84,15 @@ class LogEntryRepository extends DocumentRepository
         if ($logs) {
             $data = array();
             while (($log = array_shift($logs))) {
-                $data = array_merge($data, $log->getData());
+                $logData = $log->getData();
+                foreach ($logData as $field => $value) {
+                    if ($value && $wrapped->isEmbeddedCollectionAssociation($field)) {
+                        foreach ($value as $i => $item) {
+                            $logData[$field][$i] = array_merge(@$data[$field][$i] ?: [], $item);
+                        }
+                    }
+                }
+                $data = array_merge($data, $logData);
             }
             $this->fillDocument($document, $data, $objectMeta);
         } else {

--- a/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
@@ -30,10 +30,12 @@ class LogEntryRepository extends DocumentRepository
      * given $document
      *
      * @param object $document
+     * @param null|int $limit
+     * @param null|int $skip
      *
      * @return LogEntry[]
      */
-    public function getLogEntries($document)
+    public function getLogEntries($document, $limit = null, $skip = null)
     {
         $wrapped = new MongoDocumentWrapper($document, $this->dm);
         $objectId = $wrapped->getIdentifier();
@@ -42,6 +44,12 @@ class LogEntryRepository extends DocumentRepository
         $qb->field('objectId')->equals($objectId);
         $qb->field('objectClass')->equals($wrapped->getMetadata()->name);
         $qb->sort('version', 'DESC');
+        if($limit) {
+            $qb->limit($limit);
+        }
+        if($skip) {
+            $qb->skip($skip);
+        }
         $q = $qb->getQuery();
 
         $result = $q->execute();

--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -245,6 +245,14 @@ class LoggableListener extends MappedEventSubscriber
                 continue;
             }
             $value = $changes[1];
+            if(method_exists($meta, 'isCollectionValuedEmbed') && $meta->isCollectionValuedEmbed($field) && $value) {
+                $embedValues = array();
+                foreach($value as $embedValue) {
+                    $wrapped = AbstractWrapper::wrap($embedValue, $om);
+                    $embedValues[] = $this->getObjectChangeSetData($ea, $embedValue, $logEntry);
+                }
+                $value = $embedValues;
+            }
             if ($meta->isSingleValuedAssociation($field) && $value) {
                 if ($wrapped->isEmbeddedAssociation($field)) {
                     $value = $this->getObjectChangeSetData($ea, $value, $logEntry);

--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -245,9 +245,9 @@ class LoggableListener extends MappedEventSubscriber
                 continue;
             }
             $value = $changes[1];
-            if(method_exists($meta, 'isCollectionValuedEmbed') && $meta->isCollectionValuedEmbed($field) && $value) {
+            if (method_exists($meta, 'isCollectionValuedEmbed') && $meta->isCollectionValuedEmbed($field) && $value) {
                 $embedValues = array();
-                foreach($value as $embedValue) {
+                foreach ($value as $embedValue) {
                     $wrapped = AbstractWrapper::wrap($embedValue, $om);
                     $embedValues[] = $this->getObjectChangeSetData($ea, $embedValue, $logEntry);
                 }

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -70,7 +70,13 @@ class Annotation extends AbstractAnnotationDriver
             // versioned property
             if ($this->reader->getPropertyAnnotation($property, self::VERSIONED)) {
                 $field = $property->getName();
-                if (!$this->isMappingValid($meta, $field)) {
+
+                $isEmbedMany = false;
+                if (method_exists($meta, 'isCollectionValuedEmbed')) {
+                    $isEmbedMany = $meta->isCollectionValuedEmbed($field);
+                }
+
+                if ($meta->isCollectionValuedAssociation($field) && !$isEmbedMany) {
                     throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
                 }
                 if (isset($meta->embeddedClasses[$field])) {

--- a/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
@@ -135,4 +135,11 @@ class EntityWrapper extends AbstractWrapper
     {
         return false;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmbeddedCollectionAssociation($field) {
+        return false;
+    }
 }

--- a/lib/Gedmo/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/MongoDocumentWrapper.php
@@ -134,4 +134,12 @@ class MongoDocumentWrapper extends AbstractWrapper
     {
         return $this->getMetadata()->isSingleValuedEmbed($field);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEmbeddedCollectionAssociation($field)
+    {
+        return $this->getMetadata()->isCollectionValuedEmbed($field);
+    }
 }

--- a/lib/Gedmo/Tool/WrapperInterface.php
+++ b/lib/Gedmo/Tool/WrapperInterface.php
@@ -77,11 +77,20 @@ interface WrapperInterface
     public function getRootObjectName();
 
     /**
-     * Chechks if association is embedded
+     * Checks if association is embedded
      *
      * @param string $field
      *
      * @return bool
      */
     public function isEmbeddedAssociation($field);
+
+    /**
+     * Checks if association is a collection of embedded objects
+     *
+     * @param string $field
+     *
+     * @return bool
+     */
+    public function isEmbeddedCollectionAssociation($field);
 }

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -26,6 +26,12 @@ class Article
      */
     private $author;
 
+    /**
+     * @ODM\EmbedMany(targetDocument="Reference")
+     * @Gedmo\Versioned
+     */
+    private $references;
+
     public function __toString()
     {
         return $this->title;
@@ -54,5 +60,15 @@ class Article
     public function getAuthor()
     {
         return $this->author;
+    }
+
+    public function getReferences()
+    {
+        return $this->references;
+    }
+
+    public function setReferences($references)
+    {
+        $this->references = $references;
     }
 }

--- a/tests/Gedmo/Loggable/Fixture/Document/Reference.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Reference.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Loggable\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ODM\EmbeddedDocument
+ * @Gedmo\Loggable
+ */
+class Reference
+{
+    /**
+     * @Gedmo\Versioned
+     * @ODM\String
+     */
+    private $reference;
+
+    /**
+     * @Gedmo\Versioned
+     * @ODM\String
+     */
+    private $title;
+
+    public function getReference()
+    {
+        return $this->reference;
+    }
+
+    public function setReference($reference)
+    {
+        $this->reference = $reference;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -33,6 +33,13 @@ class RelatedArticle
      */
     private $comments;
 
+    /**
+     * @ODM\EmbedMany(targetDocument="Reference")
+     * @Gedmo\Versioned
+     */
+    private $references;
+
+
     public function getId()
     {
         return $this->id;
@@ -67,5 +74,15 @@ class RelatedArticle
     public function getContent()
     {
         return $this->content;
+    }
+
+    public function getReferences()
+    {
+        return $this->references;
+    }
+
+    public function setReferences($references)
+    {
+        $this->references = $references;
     }
 }


### PR DESCRIPTION
Big thanks goes to @Engerim since the core functionality of this implementation is based on his work in https://github.com/Engerim/DoctrineExtensions/commit/079e8326ac032cdb024 
Additionally the revert functionality was adapted to support these kind of relations and the listing of log entries for an object can now be paged using optional _limit_ and _skip_ parameters

closes #1069 
closes #1260 