### PR TITLE
change odm string annotation to field with type string

### DIFF
--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -280,14 +280,14 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
      * @var string $createdBy
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="create")
      */
     private $createdBy;
@@ -295,7 +295,7 @@ class Article
     /**
      * @var string $updatedBy
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable
      */
     private $updatedBy;

--- a/doc/ip_traceable.md
+++ b/doc/ip_traceable.md
@@ -179,14 +179,14 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
      * @var string $createdFromIp
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="create")
      */
     private $createdFromIp;
@@ -194,7 +194,7 @@ class Article
     /**
      * @var string $updatedFromIp
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable
      */
     private $updatedFromIp;

--- a/doc/loggable.md
+++ b/doc/loggable.md
@@ -129,7 +129,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Versioned
      */
     private $title;

--- a/doc/reference_integrity.md
+++ b/doc/reference_integrity.md
@@ -62,7 +62,7 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/doc/references.md
+++ b/doc/references.md
@@ -67,7 +67,7 @@ class Product
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 

--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -198,18 +198,18 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $code;
 
     /**
      * @Gedmo\Slug(fields={"title", "code"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $slug;
 

--- a/doc/timestampable.md
+++ b/doc/timestampable.md
@@ -185,12 +185,12 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $body;
 

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -160,13 +160,13 @@ class Article implements Translatable
 
     /**
      * @Gedmo\Translatable
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
      * @Gedmo\Translatable
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $content;
 

--- a/lib/Gedmo/Blameable/Traits/BlameableDocument.php
+++ b/lib/Gedmo/Blameable/Traits/BlameableDocument.php
@@ -16,14 +16,14 @@ trait BlameableDocument
     /**
      * @var string
      * @Gedmo\Blameable(on="create")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $createdBy;
 
     /**
      * @var string
      * @Gedmo\Blameable(on="update")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $updatedBy;
 

--- a/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
+++ b/lib/Gedmo/IpTraceable/Traits/IpTraceableDocument.php
@@ -16,14 +16,14 @@ trait IpTraceableDocument
     /**
      * @var string
      * @Gedmo\IpTraceable(on="create")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $createdFromIp;
 
     /**
      * @var string
      * @Gedmo\IpTraceable(on="update")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $updatedFromIp;
 

--- a/lib/Gedmo/Translator/Document/Translation.php
+++ b/lib/Gedmo/Translator/Document/Translation.php
@@ -5,7 +5,7 @@ namespace Gedmo\Translator\Document;
 use Gedmo\Translator\Translation as BaseTranslation;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\String as MongoString;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * Document translation class.
@@ -25,21 +25,21 @@ abstract class Translation extends BaseTranslation
     /**
      * @var string $locale
      *
-     * @MongoString
+     * @ODM\Field(type="string")
      */
     protected $locale;
 
     /**
      * @var string $property
      *
-     * @MongoString
+     * @ODM\Field(type="string")
      */
     protected $property;
 
     /**
      * @var string $value
      *
-     * @MongoString
+     * @ODM\Field(type="string")
      */
     protected $value;
 

--- a/tests/Gedmo/Blameable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Article.php
@@ -14,7 +14,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
@@ -26,7 +26,7 @@ class Article
     /**
      * @var string $created
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="create")
      */
     private $created;
@@ -34,7 +34,7 @@ class Article
     /**
      * @var string $updated
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable
      */
     private $updated;
@@ -48,7 +48,7 @@ class Article
     /**
      * @var string $published
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="change", field="type.title", value="Published")
      */
     private $published;

--- a/tests/Gedmo/Blameable/Fixture/Document/Log.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Log.php
@@ -19,14 +19,14 @@ class Log
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $content;
 
     /**
      * @var string $created
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\Blameable(on="create")
      */
     private $created;

--- a/tests/Gedmo/Blameable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/Type.php
@@ -13,12 +13,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/Blameable/Fixture/Document/User.php
+++ b/tests/Gedmo/Blameable/Fixture/Document/User.php
@@ -13,7 +13,7 @@ class User
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $username;
 

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Article.php
@@ -14,7 +14,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
@@ -26,7 +26,7 @@ class Article
     /**
      * @var string $created
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="create")
      */
     private $created;
@@ -34,7 +34,7 @@ class Article
     /**
      * @var string $updated
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable
      */
     private $updated;
@@ -42,14 +42,14 @@ class Article
     /**
      * @var string $published
      *
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="change", field="type.title", value="Published")
      */
     private $published;
 
     /**
      * @var string
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @Gedmo\IpTraceable(on="change", field="isReady", value=true)
      */
     private $ready;

--- a/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
+++ b/tests/Gedmo/IpTraceable/Fixture/Document/Type.php
@@ -13,12 +13,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/Loggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Article.php
@@ -16,7 +16,7 @@ class Article
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Loggable/Fixture/Document/Author.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Author.php
@@ -13,13 +13,13 @@ class Author
 {
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $email;
 

--- a/tests/Gedmo/Loggable/Fixture/Document/Comment.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Comment.php
@@ -18,13 +18,13 @@ class Comment
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $subject;
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $message;
 

--- a/tests/Gedmo/Loggable/Fixture/Document/Reference.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/Reference.php
@@ -13,13 +13,13 @@ class Reference
 {
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $reference;
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
+++ b/tests/Gedmo/Loggable/Fixture/Document/RelatedArticle.php
@@ -18,13 +18,13 @@ class RelatedArticle
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
      * @Gedmo\Versioned
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $content;
 

--- a/tests/Gedmo/Mapping/Fixture/Document/User.php
+++ b/tests/Gedmo/Mapping/Fixture/Document/User.php
@@ -17,13 +17,13 @@ class User
 
     /**
      * @Ext\Encode(type="sha1", secret="xxx")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 
     /**
      * @Ext\Encode(type="md5")
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $password;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Article.php
@@ -15,7 +15,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyNullify/Type.php
@@ -17,12 +17,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Article.php
@@ -16,7 +16,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyPull/Type.php
@@ -17,12 +17,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Article.php
@@ -15,7 +15,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/ManyRestrict/Type.php
@@ -17,12 +17,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Article.php
@@ -15,7 +15,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneNullify/Type.php
@@ -16,12 +16,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Article.php
@@ -16,7 +16,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OnePull/Type.php
@@ -16,12 +16,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Article.php
@@ -15,7 +15,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
+++ b/tests/Gedmo/ReferenceIntegrity/Fixture/Document/OneRestrict/Type.php
@@ -16,12 +16,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
+++ b/tests/Gedmo/References/Fixture/ODM/MongoDB/Product.php
@@ -18,7 +18,7 @@ class Product
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 

--- a/tests/Gedmo/Sluggable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Article.php
@@ -14,18 +14,18 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $code;
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title", "code"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $slug;
 

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/Article.php
@@ -14,12 +14,12 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $code;
 
@@ -31,7 +31,7 @@ class Article
      *          @Gedmo\SlugHandlerOption(name="inverseSlugField", value="alias")
      *      })
      * }, separator="-", updatable=true, fields={"title", "code"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $slug;
 

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/RelativeSlug.php
@@ -16,7 +16,7 @@ class RelativeSlug
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
@@ -28,7 +28,7 @@ class RelativeSlug
      *          @Gedmo\SlugHandlerOption(name="separator", value="/")
      *      })
      * }, separator="-", updatable=true, fields={"title"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $alias;
 

--- a/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/Document/Handler/TreeSlug.php
@@ -16,7 +16,7 @@ class TreeSlug
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
@@ -27,7 +27,7 @@ class TreeSlug
      *          @Gedmo\SlugHandlerOption(name="separator", value="/")
      *      })
      * }, separator="-", updatable=true, fields={"title"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $alias;
 

--- a/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
+++ b/tests/Gedmo/Sluggable/Fixture/Issue1151/Article.php
@@ -18,13 +18,13 @@ class Article
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $title;
 
     /**
      * @Gedmo\Slug(separator="-", updatable=true, fields={"title"})
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $slug;
 

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/User.php
@@ -14,7 +14,7 @@ class User
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $username;
 
     /** @ODM\Date */

--- a/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Document/UserTimeAware.php
@@ -14,7 +14,7 @@ class UserTimeAware
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $username;
 
     /** @ODM\Date */

--- a/tests/Gedmo/Sortable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Article.php
@@ -14,7 +14,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Sortable/Fixture/Document/Category.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Category.php
@@ -14,7 +14,7 @@ class Category
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 

--- a/tests/Gedmo/Sortable/Fixture/Document/Kid.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Kid.php
@@ -14,7 +14,7 @@ class Kid
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $lastname;
 

--- a/tests/Gedmo/Sortable/Fixture/Document/Post.php
+++ b/tests/Gedmo/Sortable/Fixture/Document/Post.php
@@ -15,7 +15,7 @@ class Post
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Timestampable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Article.php
@@ -14,7 +14,7 @@ class Article
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Timestampable/Fixture/Document/Book.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Book.php
@@ -19,7 +19,7 @@ class Book
     protected $id;
 
     /**
-     * @ODM\String()
+     * @ODM\Field(type="string")
      * @var string
      */
     protected $title;

--- a/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Tag.php
@@ -11,7 +11,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class Tag
 {
     /**
-     * @ODM\String()
+     * @ODM\Field(type="string")
      * @var string
      */
     protected $name;

--- a/tests/Gedmo/Timestampable/Fixture/Document/Type.php
+++ b/tests/Gedmo/Timestampable/Fixture/Document/Type.php
@@ -13,12 +13,12 @@ class Type
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $title;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $identifier;
 

--- a/tests/Gedmo/Translatable/Fixture/Document/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Article.php
@@ -15,20 +15,20 @@ class Article
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $title;
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $code;
 
     /**
      * @Gedmo\Slug(fields={"title", "code"})
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $slug;
 

--- a/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/Personal/Article.php
@@ -16,7 +16,7 @@ class Article
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $title;
 

--- a/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Document/SimpleArticle.php
@@ -15,13 +15,13 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $title;
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $content;
 

--- a/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
+++ b/tests/Gedmo/Translatable/Fixture/Issue165/SimpleArticle.php
@@ -15,18 +15,18 @@ class SimpleArticle
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $title;
 
     /**
      * @Gedmo\Translatable
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $content;
 
     /**
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $untranslated;
 

--- a/tests/Gedmo/Wrapper/Fixture/Document/Article.php
+++ b/tests/Gedmo/Wrapper/Fixture/Document/Article.php
@@ -13,7 +13,7 @@ class Article
     private $id;
 
     /**
-     * @MongoODM\String
+     * @MongoODM\Field(type="string")
      */
     private $title;
 


### PR DESCRIPTION
This changes are fixed error, which appears in php v. > 7 - [RuntimeException]                                                                                                                                                       
  An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                
  PHP Fatal error:  Cannot use 'String' as class name as it is reserved in 