### PR TITLE
Support for Symfony 2.6 and above

### DIFF
--- a/doc/symfony2.md
+++ b/doc/symfony2.md
@@ -239,6 +239,7 @@ namespace Acme\DemoBundle\Listener;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class DoctrineExtensionListener implements ContainerAwareInterface
 {
@@ -266,10 +267,22 @@ class DoctrineExtensionListener implements ContainerAwareInterface
 
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $securityContext = $this->container->get('security.context', ContainerInterface::NULL_ON_INVALID_REFERENCE);
-        if (null !== $securityContext && null !== $securityContext->getToken() && $securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
-            $loggable = $this->container->get('gedmo.listener.loggable');
-            $loggable->setUsername($securityContext->getToken()->getUsername());
+        if (Kernel::MAJOR_VERSION == 2 && Kernel::MINOR_VERSION < 6) {
+            $securityContext = $this->container->get('security.context', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+            if (null !== $securityContext && null !== $securityContext->getToken() && $securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+                $loggable = $this->container->get('gedmo.listener.loggable');
+                $loggable->setUsername($securityContext->getToken()->getUsername());
+            }
+        }
+        else {
+            $tokenStorage = $this->container->get('security.token_storage')->getToken();
+            $authorizationChecker = $this->container->get('security.authorization_checker');
+            if (null !== $tokenStorage && $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+                $loggable = $this->container->get('gedmo.listener.loggable');
+                $loggable->setUsername($tokenStorage->getUser());
+                $blameable = $this->container->get('gedmo.listener.blameable');
+                $blameable->setUserValue($tokenStorage->getUser());
+            }
         }
     }
 }


### PR DESCRIPTION
Modified DoctrineExtensionListener to support both Symfony < 2.6 and Symfony >= 2.6 and to support blameable extension too.