### PR TITLE
Ensure children elements in Gedmo namespace are found

### DIFF
--- a/lib/Gedmo/Blameable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Blameable/Mapping/Driver/Xml.php
@@ -45,7 +45,7 @@ class Xml extends BaseXml
             foreach ($mapping->field as $fieldMapping) {
                 $fieldMappingDoctrine = $fieldMapping;
                 $fieldMapping = $fieldMapping->children(self::GEDMO_NAMESPACE_URI);
-                if (isset($fieldMapping->blameable)) {
+                if ($fieldMapping->count() > 0 && isset($fieldMapping->blameable)) {
                     /**
                      * @var \SimpleXmlElement $data
                      */
@@ -83,7 +83,7 @@ class Xml extends BaseXml
             foreach ($mapping->{'many-to-one'} as $fieldMapping) {
                 $field = $this->_getAttribute($fieldMapping, 'field');
                 $fieldMapping = $fieldMapping->children(self::GEDMO_NAMESPACE_URI);
-                if (isset($fieldMapping->blameable)) {
+                if ($fieldMapping->count() > 0 && isset($fieldMapping->blameable)) {
                     $data = $fieldMapping->blameable;
                     if (! $meta->isSingleValuedAssociation($field)) {
                         throw new InvalidMappingException("Association - [{$field}] is not valid, it must be a one-to-many relation or a string field - {$meta->name}");

--- a/lib/Gedmo/IpTraceable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/IpTraceable/Mapping/Driver/Xml.php
@@ -44,7 +44,7 @@ class Xml extends BaseXml
             foreach ($mapping->field as $fieldMapping) {
                 $fieldMappingDoctrine = $fieldMapping;
                 $fieldMapping = $fieldMapping->children(self::GEDMO_NAMESPACE_URI);
-                if (isset($fieldMapping->{'ip-traceable'})) {
+                if ($fieldMapping->count() > 0 && isset($fieldMapping->{'ip-traceable'})) {
                     /**
                      * @var \SimpleXmlElement $data
                      */
@@ -82,7 +82,7 @@ class Xml extends BaseXml
             foreach ($mapping->{'many-to-one'} as $fieldMapping) {
                 $field = $this->_getAttribute($fieldMapping, 'field');
                 $fieldMapping = $fieldMapping->children(self::GEDMO_NAMESPACE_URI);
-                if (isset($fieldMapping->{'ip-traceable'})) {
+                if ($fieldMapping->count() > 0 && isset($fieldMapping->{'ip-traceable'})) {
                     /**
                      * @var \SimpleXmlElement $data
                      */

--- a/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
@@ -32,7 +32,7 @@ class Xml extends BaseXml
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
         if ($xmlDoctrine->getName() == 'entity' || $xmlDoctrine->getName() == 'document' || $xmlDoctrine->getName() == 'mapped-superclass') {
-            if (isset($xml->loggable)) {
+            if ($xml->count() > 0 && isset($xml->loggable)) {
                 /**
                  * @var \SimpleXMLElement $data;
                  */
@@ -93,7 +93,7 @@ class Xml extends BaseXml
             $isAssoc = $this->_isAttributeSet($mappingDoctrine, 'field');
             $field = $this->_getAttribute($mappingDoctrine, $isAssoc ? 'field' : 'name');
 
-            if (isset($mapping->versioned)) {
+            if ($mapping->count() > 0 && isset($mapping->versioned)) {
                 if ($isAssoc && !$meta->associationMappings[$field]['isOwningSide']) {
                     throw new InvalidMappingException("Cannot version [{$field}] as it is not the owning side in object - {$meta->name}");
                 }

--- a/lib/Gedmo/References/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/References/Mapping/Driver/Xml.php
@@ -47,7 +47,7 @@ class Xml extends BaseXml
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
         if ($xmlDoctrine->getName() === 'entity' || $xmlDoctrine->getName() === 'document' || $xmlDoctrine->getName() === 'mapped-superclass') {
-            if (isset($xml->reference)) {
+            if ($xml->count() > 0 && isset($xml->reference)) {
                 /**
                  * @var \SimpleXMLElement $element
                  */

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -50,7 +50,7 @@ class Xml extends BaseXml
                 $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
 
                 $field = $this->_getAttribute($mappingDoctrine, 'name');
-                if (isset($mapping->slug)) {
+                if ($mapping->count() > 0 && isset($mapping->slug)) {
                     /**
                      * @var \SimpleXmlElement $slug
                      */

--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
@@ -32,7 +32,7 @@ class Xml extends BaseXml
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
         if (in_array($xmlDoctrine->getName(), array('mapped-superclass', 'entity', 'document', 'embedded-document'))) {
-            if (isset($xml->{'soft-deleteable'})) {
+            if ($xml->count() > 0 && isset($xml->{'soft-deleteable'})) {
                 $field = $this->_getAttribute($xml->{'soft-deleteable'}, 'field-name');
 
                 if (!$field) {

--- a/lib/Gedmo/Sortable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sortable/Mapping/Driver/Xml.php
@@ -43,7 +43,7 @@ class Xml extends BaseXml
                 $mapping = $mappingDoctrine->children(self::GEDMO_NAMESPACE_URI);
 
                 $field = $this->_getAttribute($mappingDoctrine, 'name');
-                if (isset($mapping->sortable)) {
+                if ($mapping->count() > 0 && isset($mapping->sortable)) {
                     $sortable = $mapping->sortable;
                     if (!$this->isValidField($meta, $field)) {
                         throw new InvalidMappingException("Sortable position field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");

--- a/lib/Gedmo/Timestampable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Timestampable/Mapping/Driver/Xml.php
@@ -50,7 +50,7 @@ class Xml extends BaseXml
             foreach ($mapping->field as $fieldMapping) {
                 $fieldMappingDoctrine = $fieldMapping;
                 $fieldMapping = $fieldMapping->children(self::GEDMO_NAMESPACE_URI);
-                if (isset($fieldMapping->timestampable)) {
+                if ($fieldMapping->count() > 0 && isset($fieldMapping->timestampable)) {
                     /**
                      * @var \SimpleXmlElement $data
                      */

--- a/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
@@ -31,7 +31,7 @@ class Xml extends BaseXml
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
         if (($xmlDoctrine->getName() == 'entity' || $xmlDoctrine->getName() == 'mapped-superclass')) {
-            if (isset($xml->translation)) {
+            if ($xml->count() && isset($xml->translation)) {
                 /**
                  * @var \SimpleXmlElement $data
                  */
@@ -80,7 +80,7 @@ class Xml extends BaseXml
              */
             $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
             $field = null !== $prefix ? $prefix . '.' . $this->_getAttribute($mappingDoctrine, 'name') : $this->_getAttribute($mappingDoctrine, 'name');
-            if (isset($mapping->translatable)) {
+            if ($mapping->count() > 0 && isset($mapping->translatable)) {
                 $config['fields'][] = $field;
                 /** @var \SimpleXmlElement $data */
                 $data = $mapping->translatable;

--- a/lib/Gedmo/Tree/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Tree/Mapping/Driver/Xml.php
@@ -43,7 +43,7 @@ class Xml extends BaseXml
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
         $validator = new Validator();
 
-        if (isset($xml->tree) && $this->_isAttributeSet($xml->tree, 'type')) {
+        if ($xml->count() > 0 && isset($xml->tree) && $this->_isAttributeSet($xml->tree, 'type')) {
             $strategy = $this->_getAttribute($xml->tree, 'type');
             if (!in_array($strategy, $this->strategies)) {
                 throw new InvalidMappingException("Tree type: $strategy is not available.");
@@ -74,76 +74,78 @@ class Xml extends BaseXml
                 $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
 
                 $field = $this->_getAttribute($mappingDoctrine, 'name');
-                if (isset($mapping->{'tree-left'})) {
-                    if (!$validator->isValidField($meta, $field)) {
-                        throw new InvalidMappingException("Tree left field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
-                    }
-                    $config['left'] = $field;
-                } elseif (isset($mapping->{'tree-right'})) {
-                    if (!$validator->isValidField($meta, $field)) {
-                        throw new InvalidMappingException("Tree right field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
-                    }
-                    $config['right'] = $field;
-                } elseif (isset($mapping->{'tree-root'})) {
-                    if (!$validator->isValidFieldForRoot($meta, $field)) {
-                        throw new InvalidMappingException("Tree root field - [{$field}] type is not valid and must be any of the 'integer' types or 'string' in class - {$meta->name}");
-                    }
-                    $config['root'] = $field;
-                } elseif (isset($mapping->{'tree-level'})) {
-                    if (!$validator->isValidField($meta, $field)) {
-                        throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
-                    }
-                    $config['level'] = $field;
-                } elseif (isset($mapping->{'tree-path'})) {
-                    if (!$validator->isValidFieldForPath($meta, $field)) {
-                        throw new InvalidMappingException("Tree Path field - [{$field}] type is not valid. It must be string or text in class - {$meta->name}");
-                    }
+                if($mapping->count() > 0) {
+                    if (isset($mapping->{'tree-left'})) {
+                        if (!$validator->isValidField($meta, $field)) {
+                            throw new InvalidMappingException("Tree left field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
+                        }
+                        $config['left'] = $field;
+                    } elseif (isset($mapping->{'tree-right'})) {
+                        if (!$validator->isValidField($meta, $field)) {
+                            throw new InvalidMappingException("Tree right field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
+                        }
+                        $config['right'] = $field;
+                    } elseif (isset($mapping->{'tree-root'})) {
+                        if (!$validator->isValidFieldForRoot($meta, $field)) {
+                            throw new InvalidMappingException("Tree root field - [{$field}] type is not valid and must be any of the 'integer' types or 'string' in class - {$meta->name}");
+                        }
+                        $config['root'] = $field;
+                    } elseif (isset($mapping->{'tree-level'})) {
+                        if (!$validator->isValidField($meta, $field)) {
+                            throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
+                        }
+                        $config['level'] = $field;
+                    } elseif (isset($mapping->{'tree-path'})) {
+                        if (!$validator->isValidFieldForPath($meta, $field)) {
+                            throw new InvalidMappingException("Tree Path field - [{$field}] type is not valid. It must be string or text in class - {$meta->name}");
+                        }
 
-                    $separator = $this->_getAttribute($mapping->{'tree-path'}, 'separator');
+                        $separator = $this->_getAttribute($mapping->{'tree-path'}, 'separator');
 
-                    if (strlen($separator) > 1) {
-                        throw new InvalidMappingException("Tree Path field - [{$field}] Separator {$separator} is invalid. It must be only one character long.");
+                        if (strlen($separator) > 1) {
+                            throw new InvalidMappingException("Tree Path field - [{$field}] Separator {$separator} is invalid. It must be only one character long.");
+                        }
+
+                        $appendId = $this->_getAttribute($mapping->{'tree-path'}, 'append_id');
+
+                        if (!$appendId) {
+                            $appendId = true;
+                        } else {
+                            $appendId = strtolower($appendId) == 'false' ? false : true;
+                        }
+
+                        $startsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'starts_with_separator');
+
+                        if (!$startsWithSeparator) {
+                            $startsWithSeparator = false;
+                        } else {
+                            $startsWithSeparator = strtolower($startsWithSeparator) == 'false' ? false : true;
+                        }
+
+                        $endsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'ends_with_separator');
+
+                        if (!$endsWithSeparator) {
+                            $endsWithSeparator = true;
+                        } else {
+                            $endsWithSeparator = strtolower($endsWithSeparator) == 'false' ? false : true;
+                        }
+
+                        $config['path'] = $field;
+                        $config['path_separator'] = $separator;
+                        $config['path_append_id'] = $appendId;
+                        $config['path_starts_with_separator'] = $startsWithSeparator;
+                        $config['path_ends_with_separator'] = $endsWithSeparator;
+                    } elseif (isset($mapping->{'tree-path-source'})) {
+                        if (!$validator->isValidFieldForPathSource($meta, $field)) {
+                            throw new InvalidMappingException("Tree PathSource field - [{$field}] type is not valid. It can be any of the integer variants, double, float or string in class - {$meta->name}");
+                        }
+                        $config['path_source'] = $field;
+                    } elseif (isset($mapping->{'tree-lock-time'})) {
+                        if (!$validator->isValidFieldForLockTime($meta, $field)) {
+                            throw new InvalidMappingException("Tree LockTime field - [{$field}] type is not valid. It must be \"date\" in class - {$meta->name}");
+                        }
+                        $config['lock_time'] = $field;
                     }
-
-                    $appendId = $this->_getAttribute($mapping->{'tree-path'}, 'append_id');
-
-                    if (!$appendId) {
-                        $appendId = true;
-                    } else {
-                        $appendId = strtolower($appendId) == 'false' ? false : true;
-                    }
-
-                    $startsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'starts_with_separator');
-
-                    if (!$startsWithSeparator) {
-                        $startsWithSeparator = false;
-                    } else {
-                        $startsWithSeparator = strtolower($startsWithSeparator) == 'false' ? false : true;
-                    }
-
-                    $endsWithSeparator = $this->_getAttribute($mapping->{'tree-path'}, 'ends_with_separator');
-
-                    if (!$endsWithSeparator) {
-                        $endsWithSeparator = true;
-                    } else {
-                        $endsWithSeparator = strtolower($endsWithSeparator) == 'false' ? false : true;
-                    }
-
-                    $config['path'] = $field;
-                    $config['path_separator'] = $separator;
-                    $config['path_append_id'] = $appendId;
-                    $config['path_starts_with_separator'] = $startsWithSeparator;
-                    $config['path_ends_with_separator'] = $endsWithSeparator;
-                } elseif (isset($mapping->{'tree-path-source'})) {
-                    if (!$validator->isValidFieldForPathSource($meta, $field)) {
-                        throw new InvalidMappingException("Tree PathSource field - [{$field}] type is not valid. It can be any of the integer variants, double, float or string in class - {$meta->name}");
-                    }
-                    $config['path_source'] = $field;
-                } elseif (isset($mapping->{'tree-lock-time'})) {
-                    if (!$validator->isValidFieldForLockTime($meta, $field)) {
-                        throw new InvalidMappingException("Tree LockTime field - [{$field}] type is not valid. It must be \"date\" in class - {$meta->name}");
-                    }
-                    $config['lock_time'] = $field;
                 }
             }
         }
@@ -160,21 +162,23 @@ class Xml extends BaseXml
                      */
                     $manyToOneMappingDoctrine = $manyToOneMapping;
                     $manyToOneMapping = $manyToOneMapping->children(self::GEDMO_NAMESPACE_URI);
-                    if (isset($manyToOneMapping->{'tree-parent'})) {
-                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
-                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
-                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
-                            throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                    if($manyToOneMapping->count() > 0) {
+                        if (isset($manyToOneMapping->{'tree-parent'})) {
+                            $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                            $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                            if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                                throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['parent'] = $field;
                         }
-                        $config['parent'] = $field;
-                    }
-                    if (isset($manyToOneMapping->{'tree-root'})) {
-                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
-                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
-                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
-                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        if (isset($manyToOneMapping->{'tree-root'})) {
+                            $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                            $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                            if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                                throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['root'] = $field;
                         }
-                        $config['root'] = $field;
                     }
                 }
             } elseif (isset($xmlDoctrine->{'reference-one'})) {
@@ -184,19 +188,21 @@ class Xml extends BaseXml
                      */
                     $referenceOneMappingDoctrine = $referenceOneMapping;
                     $referenceOneMapping = $referenceOneMapping->children(self::GEDMO_NAMESPACE_URI);
-                    if (isset($referenceOneMapping->{'tree-parent'})) {
-                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
-                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
-                            throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                    if($referenceOneMapping->count() > 0) {
+                        if (isset($referenceOneMapping->{'tree-parent'})) {
+                            $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                            if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                                throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['parent'] = $field;
                         }
-                        $config['parent'] = $field;
-                    }
-                    if (isset($referenceOneMapping->{'tree-root'})) {
-                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
-                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
-                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        if (isset($referenceOneMapping->{'tree-root'})) {
+                            $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                            if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                                throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['root'] = $field;
                         }
-                        $config['root'] = $field;
                     }
                 }
             }
@@ -208,21 +214,23 @@ class Xml extends BaseXml
                      */
                     $manyToOneMappingDoctrine = $manyToOneMapping;
                     $manyToOneMapping = $manyToOneMapping->children(self::GEDMO_NAMESPACE_URI);
-                    if (isset($manyToOneMapping->{'tree-parent'})) {
-                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
-                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
-                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
-                            throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                    if($manyToOneMapping->count() > 0) {
+                        if (isset($manyToOneMapping->{'tree-parent'})) {
+                            $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                            $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                            if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                                throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['parent'] = $field;
                         }
-                        $config['parent'] = $field;
-                    }
-                    if (isset($manyToOneMapping->{'tree-root'})) {
-                        $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
-                        $targetEntity = $meta->associationMappings[$field]['targetEntity'];
-                        if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
-                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        if (isset($manyToOneMapping->{'tree-root'})) {
+                            $field = $this->_getAttribute($manyToOneMappingDoctrine, 'field');
+                            $targetEntity = $meta->associationMappings[$field]['targetEntity'];
+                            if (!$cl = $this->getRelatedClassName($meta, $targetEntity)) {
+                                throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['root'] = $field;
                         }
-                        $config['root'] = $field;
                     }
                 }
             }
@@ -234,19 +242,21 @@ class Xml extends BaseXml
                      */
                     $referenceOneMappingDoctrine = $referenceOneMapping;
                     $referenceOneMapping = $referenceOneMapping->children(self::GEDMO_NAMESPACE_URI);
-                    if (isset($referenceOneMapping->{'tree-parent'})) {
-                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
-                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
-                            throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                    if($referenceOneMapping->count() > 0) {
+                        if (isset($referenceOneMapping->{'tree-parent'})) {
+                            $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                            if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                                throw new InvalidMappingException("Unable to find ancestor/parent child relation through ancestor field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['parent'] = $field;
                         }
-                        $config['parent'] = $field;
-                    }
-                    if (isset($referenceOneMapping->{'tree-root'})) {
-                        $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
-                        if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
-                            throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                        if (isset($referenceOneMapping->{'tree-root'})) {
+                            $field = $this->_getAttribute($referenceOneMappingDoctrine, 'field');
+                            if (!$cl = $this->getRelatedClassName($meta, $this->_getAttribute($referenceOneMappingDoctrine, 'target-document'))) {
+                                throw new InvalidMappingException("Unable to find root descendant relation through root field - [{$field}] in class - {$meta->name}");
+                            }
+                            $config['root'] = $field;
                         }
-                        $config['root'] = $field;
                     }
                 }
             }

--- a/lib/Gedmo/Uploadable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Uploadable/Mapping/Driver/Xml.php
@@ -30,7 +30,7 @@ class Xml extends BaseXml
         $xmlDoctrine = $xml;
         $xml = $xml->children(self::GEDMO_NAMESPACE_URI);
 
-        if ($xmlDoctrine->getName() == 'entity' || $xmlDoctrine->getName() == 'mapped-superclass') {
+        if ($xml->count() > 0 && ($xmlDoctrine->getName() == 'entity' || $xmlDoctrine->getName() == 'mapped-superclass')) {
             if (isset($xml->uploadable)) {
                 $xmlUploadable = $xml->uploadable;
                 $config['uploadable'] = true;
@@ -66,16 +66,17 @@ class Xml extends BaseXml
                         $mappingDoctrine = $mapping;
                         $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
 
-                        $field = $this->_getAttribute($mappingDoctrine, 'name');
-
-                        if (isset($mapping->{'uploadable-file-mime-type'})) {
-                            $config['fileMimeTypeField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-size'})) {
-                            $config['fileSizeField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-name'})) {
-                            $config['fileNameField'] = $field;
-                        } elseif (isset($mapping->{'uploadable-file-path'})) {
-                            $config['filePathField'] = $field;
+                        if($mapping->count() > 0) {
+                            $field = $this->_getAttribute($mappingDoctrine, 'name');
+                            if (isset($mapping->{'uploadable-file-mime-type'})) {
+                                $config['fileMimeTypeField'] = $field;
+                            } elseif (isset($mapping->{'uploadable-file-size'})) {
+                                $config['fileSizeField'] = $field;
+                            } elseif (isset($mapping->{'uploadable-file-name'})) {
+                                $config['fileNameField'] = $field;
+                            } elseif (isset($mapping->{'uploadable-file-path'})) {
+                                $config['filePathField'] = $field;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Prevents warnings like "Node no longer exists" (triggered when wrong namespace is used) by making sure child elements exist before processing it. 

Related:
https://github.com/Atlantic18/DoctrineExtensions/issues/1598
https://github.com/Atlantic18/DoctrineExtensions/issues/1625