### PR TITLE
Fix typo

### DIFF
--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -212,7 +212,7 @@ class Article
     /**
      * @var User $contentChangedBy
      *
-     * @Gedmo\Blameable(on="change", fields={"title", "body"})
+     * @Gedmo\Blameable(on="change", field={"title", "body"})
      * @ORM\ManyToOne(targetEntity="Path\To\Entity\User")
      * @ORM\JoinColumn(referencedColumnName="id")
      */


### PR DESCRIPTION
I've spent probably an hour wondering why this example doesn't work, and finally I saw that `fields` should be `field` without the `s`.