### PR TITLE
Type-hinted parameters in TimestampableListener

### DIFF
--- a/lib/Gedmo/AbstractTrackingListener.php
+++ b/lib/Gedmo/AbstractTrackingListener.php
@@ -184,7 +184,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
      * @param string           $field
      * @param AdapterInterface $eventAdapter
      */
-    abstract protected function getFieldValue($meta, $field, $eventAdapter);
+    abstract protected function getFieldValue(ClassMetadata $meta, $field, AdapterInterface $eventAdapter);
 
     /**
      * Updates a field

--- a/lib/Gedmo/Timestampable/TimestampableListener.php
+++ b/lib/Gedmo/Timestampable/TimestampableListener.php
@@ -21,7 +21,7 @@ class TimestampableListener extends AbstractTrackingListener
      * @param TimestampableAdapter $eventAdapter
      * @return mixed
      */
-    protected function getFieldValue($meta, $field, $eventAdapter)
+    protected function getFieldValue(ClassMetadata $meta, $field, TimestampableAdapter $eventAdapter)
     {
         return $eventAdapter->getDateValue($meta, $field);
     }

--- a/lib/Gedmo/Timestampable/TimestampableListener.php
+++ b/lib/Gedmo/Timestampable/TimestampableListener.php
@@ -5,6 +5,7 @@ namespace Gedmo\Timestampable;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Gedmo\AbstractTrackingListener;
 use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
+use Gedmo\Mapping\Event\AdapterInterface;
 
 /**
  * The Timestampable listener handles the update of
@@ -21,7 +22,7 @@ class TimestampableListener extends AbstractTrackingListener
      * @param TimestampableAdapter $eventAdapter
      * @return mixed
      */
-    protected function getFieldValue(ClassMetadata $meta, $field, TimestampableAdapter $eventAdapter)
+    protected function getFieldValue(ClassMetadata $meta, $field, AdapterInterface $eventAdapter)
     {
         return $eventAdapter->getDateValue($meta, $field);
     }


### PR DESCRIPTION
They were in the docblock, but not in type hinted as parameters.