### PR TITLE
Recognize "translatable" in "attribute-overrides"

### DIFF
--- a/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
@@ -53,8 +53,14 @@ class Xml extends BaseXml
 
         if (property_exists($meta, 'embeddedClasses') && $meta->embeddedClasses) {
             foreach ($meta->embeddedClasses as $propertyName => $embeddedClassInfo) {
-                $xmlEmbbededClass = $this->_getMapping($embeddedClassInfo['class']);
-                $this->inspectElementsForTranslatableFields($xmlEmbbededClass, $config, $propertyName);
+                $xmlEmbeddedClass = $this->_getMapping($embeddedClassInfo['class']);
+                $this->inspectElementsForTranslatableFields($xmlEmbeddedClass, $config, $propertyName);
+            }
+        }
+
+        if ($xmlDoctrine->{'attribute-overrides'}->count() > 0) {
+            foreach ($xmlDoctrine->{'attribute-overrides'}->{'attribute-override'} as $overrideMapping) {
+                $this->buildFieldConfiguration($this->_getAttribute($overrideMapping, 'name'), $overrideMapping->field, $config);
             }
         }
 
@@ -75,18 +81,24 @@ class Xml extends BaseXml
 
         foreach ($xml->field as $mapping) {
             $mappingDoctrine = $mapping;
-            /**
-             * @var \SimpleXmlElement $mapping
-             */
-            $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
-            $field = null !== $prefix ? $prefix . '.' . $this->_getAttribute($mappingDoctrine, 'name') : $this->_getAttribute($mappingDoctrine, 'name');
-            if ($mapping->count() > 0 && isset($mapping->translatable)) {
-                $config['fields'][] = $field;
-                /** @var \SimpleXmlElement $data */
-                $data = $mapping->translatable;
-                if ($this->_isAttributeSet($data, 'fallback')) {
-                    $config['fallback'][$field] = 'true' == $this->_getAttribute($data, 'fallback') ? true : false;
-                }
+
+            $fieldName = $this->_getAttribute($mappingDoctrine, 'name');
+            if ($prefix !== null) {
+                $fieldName = $prefix . '.' . $fieldName;
+            }
+            $this->buildFieldConfiguration($fieldName, $mapping, $config);
+        }
+    }
+
+    private function buildFieldConfiguration($fieldName, \SimpleXMLElement $mapping, array &$config)
+    {
+        $mapping = $mapping->children(self::GEDMO_NAMESPACE_URI);
+        if ($mapping->count() > 0 && isset($mapping->translatable)) {
+            $config['fields'][] = $fieldName;
+            /** @var \SimpleXmlElement $data */
+            $data = $mapping->translatable;
+            if ($this->_isAttributeSet($data, 'fallback')) {
+                $config['fallback'][$fieldName] = 'true' == $this->_getAttribute($data, 'fallback') ? true : false;
             }
         }
     }

--- a/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
@@ -45,17 +45,16 @@ class Yaml extends File implements Driver
                 $config['locale'] = $classMapping['translation']['language'];
             }
         }
+
         if (isset($mapping['fields'])) {
             foreach ($mapping['fields'] as $field => $fieldMapping) {
-                if (isset($fieldMapping['gedmo'])) {
-                    if (in_array('translatable', $fieldMapping['gedmo']) || isset($fieldMapping['gedmo']['translatable'])) {
-                        // fields cannot be overrided and throws mapping exception
-                        $config['fields'][] = $field;
-                        if (isset($fieldMapping['gedmo']['translatable']['fallback'])) {
-                            $config['fallback'][$field] = $fieldMapping['gedmo']['translatable']['fallback'];
-                        }
-                    }
-                }
+                $this->buildFieldConfiguration($field, $fieldMapping, $config);
+            }
+        }
+
+        if (isset($mapping['attributeOverride'])) {
+            foreach ($mapping['attributeOverride'] as $field => $overrideMapping) {
+                $this->buildFieldConfiguration($field, $overrideMapping, $config);
             }
         }
 
@@ -72,5 +71,18 @@ class Yaml extends File implements Driver
     protected function _loadMappingFile($file)
     {
         return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
+    }
+
+    private function buildFieldConfiguration($field, array $fieldMapping, array &$config)
+    {
+        if (isset($fieldMapping['gedmo'])) {
+            if (in_array('translatable', $fieldMapping['gedmo']) || isset($fieldMapping['gedmo']['translatable'])) {
+                // fields cannot be overrided and throws mapping exception
+                $config['fields'][] = $field;
+                if (isset($fieldMapping['gedmo']['translatable']['fallback'])) {
+                    $config['fallback'][$field] = $fieldMapping['gedmo']['translatable']['fallback'];
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Recognizes added `translatable` element to a predefined field in doctrine's `mapped-superclass`.