### PR TITLE
fix for #1634

### DIFF
--- a/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Yaml.php
@@ -73,9 +73,9 @@ class Yaml extends File implements Driver
         return \Symfony\Component\Yaml\Yaml::parse(file_get_contents($file));
     }
 
-    private function buildFieldConfiguration($field, array $fieldMapping, array &$config)
+    private function buildFieldConfiguration($field, $fieldMapping, array &$config)
     {
-        if (isset($fieldMapping['gedmo'])) {
+        if (is_array($fieldMapping) && isset($fieldMapping['gedmo'])) {
             if (in_array('translatable', $fieldMapping['gedmo']) || isset($fieldMapping['gedmo']['translatable'])) {
                 // fields cannot be overrided and throws mapping exception
                 $config['fields'][] = $field;


### PR DESCRIPTION
Do not typehint `array`, but check internally. Fixes https://github.com/Atlantic18/DoctrineExtensions/issues/1634