### PR TITLE
Fix incorrect syntax for arrays in PHP 5.3

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/ClosureTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/ClosureTreeRepository.php
@@ -404,7 +404,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
         $nodeIdField = $nodeMeta->getSingleIdentifierFieldName();
         $config = $this->listener->getConfiguration($this->_em, $nodeMeta->name);
         $closureMeta = $this->_em->getClassMetadata($config['closure']);
-        $errors = [];
+        $errors = array();
 
         $q = $this->_em->createQuery("
           SELECT COUNT(node)
@@ -486,7 +486,7 @@ class ClosureTreeRepository extends AbstractTreeRepository
             $conn->beginTransaction();
             foreach ($entries as $entry) {
                 $conn->insert($closureTable, array_combine(
-                    [$ancestorColumnName, $descendantColumnName, $depthColumnName],
+                    array($ancestorColumnName, $descendantColumnName, $depthColumnName),
                     $entry
                 ));
             }


### PR DESCRIPTION
Pull request for issue #1638 

Replace short syntax for arrays in PHP 5.3