### PR TITLE
Fix for nested set issue in php7 (see https://3v4l.org/IARp7)

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -534,6 +534,9 @@ class Nested implements Strategy
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
                     continue;
                 }
+                if (get_class($node) !== $class) {
+                    continue;
+                }
                 $oid = spl_object_hash($node);
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);
                 $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
@@ -598,6 +601,9 @@ class Nested implements Strategy
             }
             foreach ($nodes as $node) {
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
+                    continue;
+                }
+                if (get_class($node) !== $class) {
                     continue;
                 }
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);

--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -534,7 +534,7 @@ class Nested implements Strategy
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
                     continue;
                 }
-                if (get_class($node) !== $class) {
+                if ($em->getClassMetadata(get_class($node))->name !== $meta->name) {
                     continue;
                 }
                 $oid = spl_object_hash($node);
@@ -603,7 +603,7 @@ class Nested implements Strategy
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
                     continue;
                 }
-                if (get_class($node) !== $class) {
+                if ($em->getClassMetadata(get_class($node))->name !== $meta->name) {
                     continue;
                 }
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);

--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -534,9 +534,13 @@ class Nested implements Strategy
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
                     continue;
                 }
-                if ($em->getClassMetadata(get_class($node))->name !== $meta->name) {
+
+                $nodeMeta = $em->getClassMetadata(get_class($node));
+
+                if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
                     continue;
                 }
+
                 $oid = spl_object_hash($node);
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);
                 $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;
@@ -603,9 +607,13 @@ class Nested implements Strategy
                 if ($node instanceof Proxy && !$node->__isInitialized__) {
                     continue;
                 }
-                if ($em->getClassMetadata(get_class($node))->name !== $meta->name) {
+
+                $nodeMeta = $em->getClassMetadata(get_class($node));
+
+                if (!array_key_exists($config['left'], $nodeMeta->getReflectionProperties())) {
                     continue;
                 }
+
                 $left = $meta->getReflectionProperty($config['left'])->getValue($node);
                 $right = $meta->getReflectionProperty($config['right'])->getValue($node);
                 $currentRoot = isset($config['root']) ? $meta->getReflectionProperty($config['root'])->getValue($node) : null;


### PR DESCRIPTION
I'm not sure if this is the best solution but it fixed my problem.

In php 7.0, `ReflectionProperty::getValue()` creates a notice if the property does not exist. See https://3v4l.org/IARp7.  In php 7.1 it looks like it is going to throw an exception because the type doesn't match.