### PR TITLE
[2.4] Fix unique slugs with the TreeSlugHandler

### DIFF
--- a/lib/Gedmo/Sluggable/Handler/SlugHandlerWithUniqueCallbackInterface.php
+++ b/lib/Gedmo/Sluggable/Handler/SlugHandlerWithUniqueCallbackInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gedmo\Sluggable\Handler;
+
+use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
+
+/**
+ * This adds the ability to a SlugHandler to change the slug just before its
+ * uniqueness is ensured. It is also called if the unique options is _not_
+ * set.
+ *
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+interface SlugHandlerWithUniqueCallbackInterface extends SlugHandlerInterface
+{
+    /**
+     * Callback for slug handlers before it is made unique
+     *
+     * @param SluggableAdapter $ea
+     * @param array            $config
+     * @param object           $object
+     * @param string           $slug
+     *
+     * @return void
+     */
+    public function beforeMakingUnique(SluggableAdapter $ea, array &$config, $object, &$slug);
+}

--- a/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
+++ b/lib/Gedmo/Sluggable/Handler/TreeSlugHandler.php
@@ -17,7 +17,7 @@ use Gedmo\Exception\InvalidMappingException;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TreeSlugHandler implements SlugHandlerInterface
+class TreeSlugHandler implements SlugHandlerWithUniqueCallbackInterface
 {
     const SEPARATOR = '/';
 
@@ -128,10 +128,16 @@ class TreeSlugHandler implements SlugHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug)
+    public function beforeMakingUnique(SluggableAdapter $ea, array &$config, $object, &$slug)
     {
         $slug = $this->transliterate($slug, $config['separator'], $object);
+    }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function onSlugCompletion(SluggableAdapter $ea, array &$config, $object, &$slug)
+    {
         if (!$this->isInsert) {
             $wrapped = AbstractWrapper::wrap($object, $this->om);
             $meta = $wrapped->getMetadata();

--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -4,6 +4,7 @@ namespace Gedmo\Sluggable;
 
 use Doctrine\Common\EventArgs;
 use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\Sluggable\Handler\SlugHandlerWithUniqueCallbackInterface;
 use Gedmo\Sluggable\Mapping\Event\SluggableAdapter;
 use Doctrine\Common\Persistence\ObjectManager;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
@@ -382,6 +383,16 @@ class SluggableListener extends MappedEventSubscriber
 
                 if (isset($mapping['nullable']) && $mapping['nullable'] && !$slug) {
                     $slug = null;
+                }
+
+                // notify slug handlers --> beforeMakingUnique
+                if ($hasHandlers) {
+                    foreach ($options['handlers'] as $class => $handlerOptions) {
+                        $handler = $this->getHandler($class);
+                        if ($handler instanceof SlugHandlerWithUniqueCallbackInterface) {
+                            $handler->beforeMakingUnique($ea, $options, $object, $slug);
+                        }
+                    }
                 }
 
                 // make unique slug if requested

--- a/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
+++ b/tests/Gedmo/Sluggable/Handlers/TreeSlugHandlerUniqueTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Gedmo\Tree\TreeListener;
+use Sluggable\Fixture\Handler\TreeSlug;
+use Tool\BaseTestCaseORM;
+
+class TreeSlugHandlerUniqueTest extends BaseTestCaseORM
+{
+    const TARGET = "Sluggable\\Fixture\\Handler\\TreeSlug";
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SluggableListener());
+        $evm->addEventSubscriber(new TreeListener());
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    public function testUniqueRoot()
+    {
+        $foo1 = new TreeSlug();
+        $foo1->setTitle('Foo');
+
+        $foo2 = new TreeSlug();
+        $foo2->setTitle('Foo');
+
+        $this->em->persist($foo1);
+        $this->em->persist($foo2);
+
+        $this->em->flush();
+
+        $this->assertEquals('foo', $foo1->getSlug());
+        $this->assertEquals('foo-1', $foo2->getSlug());
+    }
+
+    public function testUniqueLeaf()
+    {
+        $root = new TreeSlug();
+        $root->setTitle('root');
+
+        $foo1 = new TreeSlug();
+        $foo1->setTitle('Foo');
+        $foo1->setParent($root);
+
+        $foo2 = new TreeSlug();
+        $foo2->setTitle('Foo');
+        $foo2->setParent($root);
+
+        $this->em->persist($root);
+        $this->em->persist($foo1);
+        $this->em->persist($foo2);
+
+        $this->em->flush();
+
+        $this->assertEquals('root/foo', $foo1->getSlug());
+        $this->assertEquals('root/foo-1', $foo2->getSlug());
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::TARGET,
+        );
+    }
+}


### PR DESCRIPTION
_This is the same as #1648 but for the 2.4 branch._
- Added test case for #1429 and #1604
- Added new callback before the slug's uniqueness is ensured while maintaining backward compatibility.