### PR TITLE
Fix node deletion for similar paths with materialized path strategy

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/MaterializedPath.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/MaterializedPath.php
@@ -23,12 +23,18 @@ class MaterializedPath extends AbstractMaterializedPath
         $wrapped = AbstractWrapper::wrap($node, $om);
 
         $path = addcslashes($wrapped->getPropertyValue($config['path']), '%');
+        $lvl = $wrapped->getPropertyValue($config['level']);
 
         // Remove node's children
         $qb = $om->createQueryBuilder();
         $qb->select('e')
             ->from($config['useObjectClass'], 'e')
             ->where($qb->expr()->like('e.'.$config['path'], $qb->expr()->literal($path.'%')));
+        
+        if(!empty($lvl) && $meta->hasField($config['level'])){
+            $qb->andWhere($qb->expr()->gt('e.'.$config['level'], $qb->expr()->literal($lvl)));
+        }
+        
         $results = $qb->getQuery()
             ->execute();
 


### PR DESCRIPTION
When deleting a node with a path that is contained in other paths, those nodes will be deleted as well.

Example:
node1: /one/two
node2: /one/two/three
node3: /one/two-test

**Problem**:
Deleting node1 will delete all three nodes.

**Expectation**:

Deleting node1 will delete nodes 1 and 2.