### PR TITLE
Fix issue #1666 QueryAnalyzer fails when parameters contains array

### DIFF
--- a/lib/Gedmo/Tool/Logging/DBAL/QueryAnalyzer.php
+++ b/lib/Gedmo/Tool/Logging/DBAL/QueryAnalyzer.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tool\Logging\DBAL;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -225,6 +226,8 @@ class QueryAnalyzer implements SQLLogger
                 }
                 if ($type instanceof Type) {
                     $value = $type->convertToDatabaseValue($value, $this->platform);
+                } elseif ($type === Connection::PARAM_INT_ARRAY || $type === Connection::PARAM_STR_ARRAY) {
+                    $value = serialize($value);
                 }
             } else {
                 if (is_object($value) && $value instanceof \DateTime) {


### PR DESCRIPTION
Fixed Issue #1666 
Added conversion of parameters with type: Connection::PARAM_INT_ARRAY and Connection::PARAM_STR_ARRAY which fix Array to string conversion notice

Please, include this fix to version 2.3.x