### PR TITLE
Fix url for xsd schemas

### DIFF
--- a/lib/Gedmo/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Mapping/Driver/Xml.php
@@ -18,7 +18,7 @@ use SimpleXMLElement;
  */
 abstract class Xml extends File
 {
-    const GEDMO_NAMESPACE_URI = 'http://gediminasm.org/schemas/orm/doctrine-extensions-mapping';
+    const GEDMO_NAMESPACE_URI = 'http://Atlantic18.github.io/DoctrineExtensions/schemas/orm/doctrine-extensions-2.4.xsd';
     const DOCTRINE_NAMESPACE_URI = 'http://doctrine-project.org/schemas/orm/doctrine-mapping';
 
     /**


### PR DESCRIPTION
http://gediminasm.org/schemas/orm/doctrine-extensions-mapping now return a 404