### PR TITLE
Use now expression for timeAware filter constraint to prevent cached times from being used for filtering

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -43,7 +43,7 @@ class SoftDeleteableFilter extends SQLFilter
 
         $addCondSql = $platform->getIsNullExpression($targetTableAlias.'.'.$column);
         if (isset($config['timeAware']) && $config['timeAware']) {
-            $now = $conn->quote(date($platform->getDateTimeFormatString())); // should use UTC in database and PHP
+            $now = $platform->getNowExpression();
             $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$now})";
         }
 


### PR DESCRIPTION
As suggested by @l3pp4rd at https://github.com/Atlantic18/DoctrineExtensions/issues/1356