### PR TITLE
[Tree] Fix positioning for rootless trees

### DIFF
--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -402,8 +402,8 @@ class Nested implements Strategy
 
             switch ($position) {
                 case self::PREV_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $siblingInPosition) {
+                        $wrappedSibling = AbstractWrapper::wrap($siblingInPosition, $em);
                         $start = $wrappedSibling->getPropertyValue($config['left']);
                     } else {
                         $wrapped->setPropertyValue($config['parent'], null);
@@ -413,8 +413,8 @@ class Nested implements Strategy
                     break;
 
                 case self::NEXT_SIBLING:
-                    if (property_exists($node, 'sibling')) {
-                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                    if (null !== $siblingInPosition) {
+                        $wrappedSibling = AbstractWrapper::wrap($siblingInPosition, $em);
                         $start = $wrappedSibling->getPropertyValue($config['right']) + 1;
                     } else {
                         $wrapped->setPropertyValue($config['parent'], null);

--- a/lib/Gedmo/Tree/Strategy/ORM/Nested.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Nested.php
@@ -390,10 +390,59 @@ class Nested implements Strategy
             }
             $newRoot = $parentRoot;
         } elseif (!isset($config['root'])) {
-            $start = isset($this->treeEdges[$meta->name]) ?
-                $this->treeEdges[$meta->name] : $this->max($em, $config['useObjectClass']);
-            $this->treeEdges[$meta->name] = $start + 2;
-            $start++;
+
+            if (!isset($this->treeEdges[$meta->name])) {
+                $this->treeEdges[$meta->name] = $this->max($em, $config['useObjectClass']) + 1;
+            }
+
+            $level = 0;
+            $parentLeft = 0;
+            $parentRight = $this->treeEdges[$meta->name];
+            $this->treeEdges[$meta->name] += 2;
+
+            switch ($position) {
+                case self::PREV_SIBLING:
+                    if (property_exists($node, 'sibling')) {
+                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                        $start = $wrappedSibling->getPropertyValue($config['left']);
+                    } else {
+                        $wrapped->setPropertyValue($config['parent'], null);
+                        $em->getUnitOfWork()->recomputeSingleEntityChangeSet($meta, $node);
+                        $start = $parentLeft + 1;
+                    }
+                    break;
+
+                case self::NEXT_SIBLING:
+                    if (property_exists($node, 'sibling')) {
+                        $wrappedSibling = AbstractWrapper::wrap($node->sibling, $em);
+                        $start = $wrappedSibling->getPropertyValue($config['right']) + 1;
+                    } else {
+                        $wrapped->setPropertyValue($config['parent'], null);
+                        $em->getUnitOfWork()->recomputeSingleEntityChangeSet($meta, $node);
+                        $start = $parentRight;
+                    }
+                    break;
+
+                case self::LAST_CHILD:
+                    $start = $parentRight;
+                    break;
+
+                case self::FIRST_CHILD:
+                default:
+                    $start = $parentLeft + 1;
+                    break;
+            }
+
+            $this->shiftRL($em, $config['useObjectClass'], $start, $treeSize, null);
+
+            if (!$isNewNode && $left >= $start) {
+                $left += $treeSize;
+                $wrapped->setPropertyValue($config['left'], $left);
+            }
+            if (!$isNewNode && $right >= $start) {
+                $right += $treeSize;
+                $wrapped->setPropertyValue($config['right'], $right);
+            }
         } else {
             $start = 1;
 
@@ -405,6 +454,7 @@ class Nested implements Strategy
         }
 
         $diff = $start - $left;
+
         if (!$isNewNode) {
             $levelDiff = isset($config['level']) ? $level - $wrapped->getPropertyValue($config['level']) : null;
             $this->shiftRangeRL(

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -333,6 +333,65 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $this->assertTrue($repo->verify());
     }
 
+    public function testRootlessTreeTopLevelInserts()
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+
+        // test top level positioned inserts
+        $fruits = new Category();
+        $fruits->setTitle('Fruits');
+
+        $vegetables = new Category();
+        $vegetables->setTitle('Vegetables');
+
+        $milk = new Category();
+        $milk->setTitle('Milk');
+
+        $meat = new Category();
+        $meat->setTitle('Meat');
+
+        $repo
+            ->persistAsFirstChild($fruits)
+            ->persistAsFirstChild($vegetables)
+            ->persistAsLastChild($milk)
+            ->persistAsLastChild($meat);
+
+        $this->em->flush();
+
+        $this->assertEquals(3, $fruits->getLeft());
+        $this->assertEquals(4, $fruits->getRight());
+
+        $this->assertEquals(1, $vegetables->getLeft());
+        $this->assertEquals(2, $vegetables->getRight());
+
+        $this->assertEquals(5, $milk->getLeft());
+        $this->assertEquals(6, $milk->getRight());
+
+        $this->assertEquals(7, $meat->getLeft());
+        $this->assertEquals(8, $meat->getRight());
+
+        // test sibling positioned inserts
+        $cookies = new Category();
+        $cookies->setTitle('Cookies');
+
+        $drinks = new Category();
+        $drinks->setTitle('Drinks');
+
+        $repo
+            ->persistAsNextSiblingOf($cookies, $milk)
+            ->persistAsPrevSiblingOf($drinks, $milk);
+
+        $this->em->flush();
+
+        $this->assertEquals(5, $drinks->getLeft());
+        $this->assertEquals(6, $drinks->getRight());
+
+        $this->assertEquals(9, $cookies->getLeft());
+        $this->assertEquals(10, $cookies->getRight());
+
+        $this->assertTrue($repo->verify());
+    }
+
     public function testSimpleTreePositionedInserts()
     {
         $repo = $this->em->getRepository(self::CATEGORY);


### PR DESCRIPTION
Here's the same fix for the `master` branch. It required a small adjustment concerning siblings but that was it. Thanks for merging!