### PR TITLE
fix translation when the value is '0' or empty string

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -470,7 +470,7 @@ class TranslatableListener extends MappedEventSubscriber
             );
             // translate object's translatable properties
             foreach ($config['fields'] as $field) {
-                $translated = '';
+                $translated = false;
                 foreach ((array) $result as $entry) {
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'];
@@ -478,7 +478,7 @@ class TranslatableListener extends MappedEventSubscriber
                     }
                 }
                 // update translation
-                if ($translated
+                if ($translated !== false
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {


### PR DESCRIPTION
# Description

I have a (ab)use case where I "translate" a boolean field. It is used to publish/unpublish translated objects based on language: most languages can see it, some must not.

I got a bug report that although unpublished the content would still show and during investigation I found that the "isPublished" field was still true. I found out that it was falling back to the base language for every PHP-falsy value; i.e. 0, "0", "".

This patch fixes that.

# Explanation of the patch

It starts with $translated set to a hard false value, and it expects that the translation field is always a string. This allows for "" and "0" to be valid translations for situations where such is desirable. If $translated is different from PHP boolean false then it is considered intentional.

# Point of thought

I haven't explored nullable columns.