### PR TITLE
fix translation when the value is falsy (e.g empty string, '0', null)

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -470,7 +470,10 @@ class TranslatableListener extends MappedEventSubscriber
             );
             // translate object's translatable properties
             foreach ($config['fields'] as $field) {
-                $translated = '';
+                // we use `new \stdClass` to mean "this has not been translated"
+                // we do this because `false`, `null`, `"0"` and the empty string are valid translations and we can't use them to determine if a translation was found or not, but we can never get an object as a translation value
+                // additionally, doing this helps contain the meta-information of "not translated" in a single variable without the chance of forgetting to set a separate `$is_translated` flag in the future
+                $translated = new \stdClass;
                 foreach ((array) $result as $entry) {
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'];
@@ -478,7 +481,7 @@ class TranslatableListener extends MappedEventSubscriber
                     }
                 }
                 // update translation
-                if ($translated
+                if (!is_object($translated)
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {


### PR DESCRIPTION
# Description

I have a (ab)use case where I "translate" a boolean field. It is used to publish/unpublish translated objects based on language: most languages can see it, some must not.

I got a bug report that although unpublished the content would still show and during investigation I found that the "isPublished" field was still true. I found out that it was falling back to the base language for every PHP-falsy value; i.e. 0, "0", "", null, false.

This patch fixes that.
# Explanation of the patch

It starts with $translated set to an impossible translation value (`new \stdClass`). This allows for "" and "0", false and null to be valid translations for situations where such is desirable.
