### PR TITLE
Add support for embeddable, add test

### DIFF
--- a/lib/Gedmo/AbstractTrackingListener.php
+++ b/lib/Gedmo/AbstractTrackingListener.php
@@ -106,12 +106,17 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                         $trackedFields = $options['trackedField'];
                     }
 
-                    foreach ($trackedFields as $tracked) {
+                    foreach ($trackedFields as $trackedField) {
                         $trackedChild = null;
-                        $parts = explode('.', $tracked);
+                        $parts = explode('.', $trackedField);
                         if (isset($parts[1])) {
                             $tracked = $parts[0];
                             $trackedChild = $parts[1];
+                        }
+
+                        if (!isset($tracked) || array_key_exists($trackedField, $changeSet)) {
+                            $tracked = $trackedField;
+                            unset($trackedChild);
                         }
 
                         if (isset($changeSet[$tracked])) {

--- a/lib/Gedmo/AbstractTrackingListener.php
+++ b/lib/Gedmo/AbstractTrackingListener.php
@@ -106,15 +106,6 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                         $trackedFields = $options['trackedField'];
                     }
 
-//                    foreach ($trackedFields as $tracked) {
-//                        $trackedChild = null;
-//                        $parts = explode('.', $tracked);
-//                        if (isset($parts[1])) {
-//                            $tracked = $parts[0];
-//                            $trackedChild = $parts[1];
-//                        }
-
-
                     foreach ($trackedFields as $trackedField) {
                         $trackedChild = null;
                         $tracked = null;

--- a/lib/Gedmo/AbstractTrackingListener.php
+++ b/lib/Gedmo/AbstractTrackingListener.php
@@ -106,8 +106,18 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                         $trackedFields = $options['trackedField'];
                     }
 
+//                    foreach ($trackedFields as $tracked) {
+//                        $trackedChild = null;
+//                        $parts = explode('.', $tracked);
+//                        if (isset($parts[1])) {
+//                            $tracked = $parts[0];
+//                            $trackedChild = $parts[1];
+//                        }
+
+
                     foreach ($trackedFields as $trackedField) {
                         $trackedChild = null;
+                        $tracked = null;
                         $parts = explode('.', $trackedField);
                         if (isset($parts[1])) {
                             $tracked = $parts[0];
@@ -116,7 +126,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
 
                         if (!isset($tracked) || array_key_exists($trackedField, $changeSet)) {
                             $tracked = $trackedField;
-                            unset($trackedChild);
+                            $trackedChild = null;
                         }
 
                         if (isset($changeSet[$tracked])) {

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -29,6 +29,11 @@ class Article implements Timestampable
     private $comments;
 
     /**
+     * @ORM\Embedded(class="Timestampable\Fixture\Author")
+     */
+    private $author;
+
+    /**
      * @var datetime $created
      *
      * @Gedmo\Timestampable(on="create")
@@ -59,6 +64,13 @@ class Article implements Timestampable
      * @Gedmo\Timestampable(on="change", field={"title", "body"})
      */
     private $contentChanged;
+    /**
+     * @var datetime $authorChanged
+     *
+     * @ORM\Column(name="author_changed", type="datetime", nullable=true)
+     * @Gedmo\Timestampable(on="change", field={"author.name", "author.email"})
+     */
+    private $authorChanged;
 
     /**
      * @ORM\ManyToOne(targetEntity="Type", inversedBy="articles")
@@ -104,6 +116,16 @@ class Article implements Timestampable
     public function getComments()
     {
         return $this->comments;
+    }
+
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(Author $author)
+    {
+        $this->author = $author;
     }
 
     /**

--- a/tests/Gedmo/Timestampable/Fixture/Article.php
+++ b/tests/Gedmo/Timestampable/Fixture/Article.php
@@ -177,4 +177,9 @@ class Article implements Timestampable
     {
         return $this->contentChanged;
     }
+
+    public function getAuthorChanged()
+    {
+        return $this->authorChanged;
+    }
 }

--- a/tests/Gedmo/Timestampable/Fixture/Author.php
+++ b/tests/Gedmo/Timestampable/Fixture/Author.php
@@ -1,0 +1,44 @@
+<?php
+namespace Timestampable\Fixture;
+
+use Gedmo\Timestampable\Timestampable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class Author
+{
+    /**
+     * @ORM\Column(name="author_name", type="string", length=128)
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(name="author_email", type="string", length=50)
+     */
+    private $email;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+
+}

--- a/tests/Gedmo/Timestampable/Fixture/Author.php
+++ b/tests/Gedmo/Timestampable/Fixture/Author.php
@@ -11,12 +11,12 @@ use Doctrine\ORM\Mapping as ORM;
 class Author
 {
     /**
-     * @ORM\Column(name="author_name", type="string", length=128)
+     * @ORM\Column(name="author_name", type="string", length=128, nullable=true)
      */
     private $name;
 
     /**
-     * @ORM\Column(name="author_email", type="string", length=50)
+     * @ORM\Column(name="author_email", type="string", length=50, nullable=true)
      */
     private $email;
 

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -144,7 +144,7 @@ class TimestampableTest extends BaseTestCaseORM
         $this->assertNotSame($su2 = $sport->getUpdated(), $su, "Date updated should change after update");
         $this->assertSame($sport->getPublished(), $sp, "Date published should remain the same after update");
         $this->assertNotSame($scc2 = $sport->getContentChanged(), $scc, "Content must have changed after update");
-        $this->assertSame($sport->authorChanged(), $sa, "Author should remain same after update");
+        $this->assertSame($sport->getAuthorChanged(), $sa, "Author should remain same after update");
 
         $author = $sport->getAuthor();
         $author->setName('Third author');

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Timestampable;
 
 use Doctrine\Common\EventManager;
+use Timestampable\Fixture\Author;
 use Tool\BaseTestCaseORM;
 use Timestampable\Fixture\Article;
 use Timestampable\Fixture\Comment;
@@ -93,6 +94,12 @@ class TimestampableTest extends BaseTestCaseORM
         $sportComment->setArticle($sport);
         $sportComment->setStatus(0);
 
+        $author = new Author();
+        $author->setName('Original author');
+        $author->setEmail('original@author.dev');
+
+        $sport->setAuthor($author);
+
         $this->em->persist($sport);
         $this->em->persist($sportComment);
         $this->em->flush();
@@ -102,6 +109,11 @@ class TimestampableTest extends BaseTestCaseORM
         $this->assertNotNull($su = $sport->getUpdated());
         $this->assertNull($sport->getContentChanged());
         $this->assertNull($sport->getPublished());
+        $this->assertNull($sport->getAuthorChanged());
+
+        $author = $sport->getAuthor();
+        $author->setName('New author');
+        $sport->setAuthor($author);
 
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneByMessage('hello');
         $this->assertNotNull($scm = $sportComment->getModified());
@@ -120,6 +132,7 @@ class TimestampableTest extends BaseTestCaseORM
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneByMessage('hello');
         $this->assertNotNull($scc = $sportComment->getClosed());
         $this->assertNotNull($sp = $sport->getPublished());
+        $this->assertNotNull($sa = $sport->getAuthorChanged());
 
         $sport->setTitle('Updated');
         $this->em->persist($sport);
@@ -131,6 +144,11 @@ class TimestampableTest extends BaseTestCaseORM
         $this->assertNotSame($su2 = $sport->getUpdated(), $su, "Date updated should change after update");
         $this->assertSame($sport->getPublished(), $sp, "Date published should remain the same after update");
         $this->assertNotSame($scc2 = $sport->getContentChanged(), $scc, "Content must have changed after update");
+        $this->assertSame($sport->authorChanged(), $sa, "Author should remain same after update");
+
+        $author = $sport->getAuthor();
+        $author->setName('Third author');
+        $sport->setAuthor($author);
 
         $sport->setBody('Body updated');
         $this->em->persist($sport);
@@ -142,6 +160,7 @@ class TimestampableTest extends BaseTestCaseORM
         $this->assertNotSame($sport->getUpdated(), $su2, "Date updated should change after update");
         $this->assertSame($sport->getPublished(), $sp, "Date published should remain the same after update");
         $this->assertNotSame($sport->getContentChanged(), $scc2, "Content must have changed after update");
+        $this->assertNotSame($sport->getAuthorChanged(), $sa, "Author must have changed after update");
     }
 
     /**


### PR DESCRIPTION
I wanted to have a Timestampable changed date that would update when embeddable properties were updated, this did not seem to work because the code is counting on the changeSet containing objects. However for embeddables, the changed property is included like "author.name". 

This PR should allow embeddable properties to be set as the fields to check for changes. I also updated the test to check this, but I couldn't get the tests running locally (PHP7) so I'm checking here if they're ok... fingers crossed. 