### PR TITLE
fix translation when the value is falsy (e.g empty string, '0', null)

### DIFF
--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -471,14 +471,16 @@ class TranslatableListener extends MappedEventSubscriber
             // translate object's translatable properties
             foreach ($config['fields'] as $field) {
                 $translated = '';
+                $is_translated = false;
                 foreach ((array) $result as $entry) {
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'];
+                        $is_translated = true;
                         break;
                     }
                 }
                 // update translation
-                if ($translated
+                if ($is_translated
                     || (!$this->translationFallback && (!isset($config['fallback'][$field]) || !$config['fallback'][$field]))
                     || ($this->translationFallback && isset($config['fallback'][$field]) && !$config['fallback'][$field])
                 ) {


### PR DESCRIPTION
# Description

I have a (ab)use case where I "translate" a boolean field. It is used to publish/unpublish translated objects based on language: most languages can see it, some must not.

I got a bug report that although unpublished the content would still show and during investigation I found that the "isPublished" field was still true. I found out that it was falling back to the base language for every PHP-falsy value; i.e. 0, "0", "", null, false.

This patch fixes that.
# Explanation of the patch

I'm using a flag variable `$is_translated` to mark if the value of `$translated` is the result of a translation. This allows `$translated` to be any value, including the falsy ones.