### PR TITLE
Use mb_strlen to get string length to avoid unicode characters problems

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -82,7 +82,7 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
         $qb->update($config['useObjectClass'], 'rec')
             ->set('rec.'.$config['slug'], $qb->expr()->concat(
                 $qb->expr()->literal($replacement),
-                $qb->expr()->substring('rec.'.$config['slug'], strlen($target))
+                $qb->expr()->substring('rec.'.$config['slug'], mb_strlen($target))
             ))
             ->where($qb->expr()->like(
                 'rec.'.$config['slug'],
@@ -105,7 +105,7 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
         $qb->update($config['useObjectClass'], 'rec')
             ->set('rec.'.$config['slug'], $qb->expr()->concat(
                 $qb->expr()->literal($target),
-                $qb->expr()->substring('rec.'.$config['slug'], strlen($replacement)+1)
+                $qb->expr()->substring('rec.'.$config['slug'], mb_strlen($replacement)+1)
             ))
             ->where($qb->expr()->like('rec.'.$config['slug'], $qb->expr()->literal($replacement . '%')))
         ;


### PR DESCRIPTION
Re-creating this pull request (including another use of `strlen`).
So, what do you think, should it be merged?