### PR TITLE
[Sluggable] Add callback support to generate slug

### DIFF
--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -12,6 +12,10 @@ Features:
 - Annotation, Yaml and Xml mapping support for extensions
 - Multiple slugs, different slugs can link to same fields
 
+Update **2016-12-28**
+
+- Callback support
+
 Update **2013-10-26**
 
 - Datetime support with default dateFormat Y-m-d-H:i
@@ -328,7 +332,8 @@ echo $article->getSlug();
 
 ### Some other configuration options for **slug** annotation:
 
-- **fields** (required, default=[]) - list of fields for slug
+- **fields** (required if **callback** is not defined, default=[]) - list of fields for slug
+- **callback** (required if **fields** is not defined, default=null) - callback method name to get slug tokens
 - **updatable** (optional, default=true) - **true** to update the slug on sluggable field changes, **false** - otherwise
 - **unique** (optional, default=true) - **true** if slug should be unique and if identical it will be prefixed, **false** - otherwise
 - **unique_base** (optional, default=null) - used in conjunction with **unique**. The name of the entity property that should be used as a key when doing a uniqueness check.
@@ -522,6 +527,52 @@ $em->flush();
 
 echo $entity->getSlug(); // outputs: "the-required-slug-set-manually"
 ```
+
+### Using a callback to define the tokens that will form the slug
+
+You can use the `callback` attribute instead of the `fields` one to define the
+parts that will form the slug. This is useful for generating slugs with pieces
+of data coming from the entity relationships and can serve as an alternative to
+the `RelativeSlugHandler`, with one limitation: it doesn't have a counterpart for
+the `InversedRelativeSlugHandler`, meaning that if the relationship changes,
+the slug won't get updated.
+
+    <?php
+    class Product
+    {
+        /**
+         * @ORM\ManyToOne(targetEntity="Brand")
+         */
+        protected $brand;
+        
+        /**
+         * @ORM\Column(name="model", type="string", length=128)
+         */
+        protected $model;
+    
+        /**
+         * @Gedmo\Slug(callback="getSlugTokens")
+         */
+        protected $slug;
+    
+        public function getBrand()
+        {
+            return $this->getBrand();
+        }
+    
+        public function getModel()
+        {
+            return $this->getModel();
+        }
+    
+        public function getSlugTokens()
+        {
+            return [
+                $this->getBrand()->getName(),
+                $this->getModel(),
+            ];
+        }
+    }
 
 ### Using TranslatableListener to translate our slug
 

--- a/lib/Gedmo/Mapping/Annotation/Slug.php
+++ b/lib/Gedmo/Mapping/Annotation/Slug.php
@@ -15,8 +15,10 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class Slug extends Annotation
 {
-    /** @var array<string> @Required */
+    /** @var array<string> */
     public $fields = array();
+    /** @var string */
+    public $callback = null;
     /** @var boolean */
     public $updatable = true;
     /** @var string */

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -95,9 +95,9 @@ class Annotation extends AbstractAnnotationDriver
                         $class::validate($handlers[$class], $meta);
                     }
                 }
-                // process slug fields
-                if (empty($slug->fields) || !is_array($slug->fields)) {
-                    throw new InvalidMappingException("Slug must contain at least one field for slug generation in class - {$meta->name}");
+                // process slug fields or callback
+                if ((empty($slug->fields) || !is_array($slug->fields)) && empty($slug->callback)) {
+                    throw new InvalidMappingException("Slug must contain at least one field or a callback for slug generation in class - {$meta->name}");
                 }
                 foreach ($slug->fields as $slugField) {
                     if (!$meta->hasField($slugField)) {
@@ -125,6 +125,7 @@ class Annotation extends AbstractAnnotationDriver
                 // set all options
                 $config['slugs'][$field] = array(
                     'fields' => $slug->fields,
+                    'callback' => $slug->callback,
                     'slug' => $field,
                     'style' => $slug->style,
                     'dateFormat' => $slug->dateFormat,

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Xml.php
@@ -58,15 +58,6 @@ class Xml extends BaseXml
                     if (!$this->isValidField($meta, $field)) {
                         throw new InvalidMappingException("Cannot use field - [{$field}] for slug storage, type is not valid and must be 'string' in class - {$meta->name}");
                     }
-                    $fields = array_map('trim', explode(',', (string) $this->_getAttribute($slug, 'fields')));
-                    foreach ($fields as $slugField) {
-                        if (!$meta->hasField($slugField)) {
-                            throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
-                        }
-                        if (!$this->isValidField($meta, $slugField)) {
-                            throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be 'string' or 'text' in class - {$meta->name}");
-                        }
-                    }
 
                     $handlers = array();
                     if (isset($slug->handler)) {
@@ -84,7 +75,9 @@ class Xml extends BaseXml
 
                     // set all options
                     $config['slugs'][$field] = array(
-                        'fields' => $fields,
+                        'fields' => $this->getFields($slug, $meta),
+                        'callback' => $this->_isAttributeSet($slug, 'callback') ?
+                            $this->_getAttribute($slug, 'callback') : null,
                         'slug' => $field,
                         'style' => $this->_isAttributeSet($slug, 'style') ?
                             $this->_getAttribute($slug, 'style') : 'default',
@@ -117,6 +110,36 @@ class Xml extends BaseXml
                 }
             }
         }
+    }
+
+    /**
+     * Get fields from attribute
+     *
+     * @param \SimpleXMLElement $slug
+     * @param object $meta
+     *
+     * @throws InvalidMappingException
+     *
+     * @return array
+     */
+    protected function getFields(\SimpleXMLElement $slug, $meta)
+    {
+        if (!$this->_isAttributeSet($slug, 'fields')) {
+            return array();
+        }
+
+        $fields = array_map('trim', explode(',', (string) $this->_getAttribute($slug, 'fields')));
+        
+        foreach ($fields as $slugField) {
+            if (!$meta->hasField($slugField)) {
+                throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
+            }
+            if (!$this->isValidField($meta, $slugField)) {
+                throw new InvalidMappingException("Cannot use field - [{$slugField}] for slug storage, type is not valid and must be 'string' or 'text' in class - {$meta->name}");
+            }
+        }
+
+        return $fields;
     }
 
     /**

--- a/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Yaml.php
@@ -99,10 +99,16 @@ class Yaml extends File implements Driver
                         $handlerClass::validate($handlers[$handlerClass], $meta);
                     }
                 }
-                // process slug fields
-                if (empty($slug['fields']) || !is_array($slug['fields'])) {
-                    throw new InvalidMappingException("Slug must contain at least one field for slug generation in class - {$meta->name}");
+
+                // process slug fields or callback
+                if ((empty($slug['fields']) || !is_array($slug['fields'])) && empty($slug['callback'])) {
+                    throw new InvalidMappingException("Slug must contain at least one field or a callback for slug generation in class - {$meta->name}");
                 }
+
+                if (empty($slug['fields'])) {
+                    $slug['fields'] = array();
+                }
+
                 foreach ($slug['fields'] as $slugField) {
                     if (!$meta->hasField($slugField)) {
                         throw new InvalidMappingException("Unable to find slug [{$slugField}] as mapped property in entity - {$meta->name}");
@@ -113,6 +119,10 @@ class Yaml extends File implements Driver
                 }
 
                 $config['slugs'][$field]['fields'] = $slug['fields'];
+
+                $config['slugs'][$field]['callback'] = isset($slug['callback']) ?
+                    (string) $slug['callback'] : null;
+                
                 $config['slugs'][$field]['handlers'] = $handlers;
                 $config['slugs'][$field]['slug'] = $field;
                 $config['slugs'][$field]['style'] = isset($slug['style']) ?

--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -298,9 +298,28 @@ class SluggableListener extends MappedEventSubscriber
                         $needToChangeSlug = true;
                     }
                     $value = $meta->getReflectionProperty($sluggableField)->getValue($object);
-                    $slug .= ($value instanceof \DateTime) ? $value->format($options['dateFormat']) : $value;
-                    $slug .= ' ';
+                    $slug = $this->addSlugToken($slug, $value, $options);
                 }
+
+
+                if (!empty($options['callback'])) {
+                    $callback = $options['callback'];
+                    $value = $object->$callback();
+
+                    if (!is_array($value)) {
+                        $value = array($value);
+                    }
+
+                    foreach ($value as $valueToken) {
+                        $slug = $this->addSlugToken($slug, $valueToken, $options);
+                    }
+
+                    if ($oldSlug !== $slug) {
+                        $needToChangeSlug = true;
+                    }
+                }
+
+                
                 // trim generated slug as it will have unnecessary trailing space
                 $slug = trim($slug);
             } else {
@@ -417,6 +436,23 @@ class SluggableListener extends MappedEventSubscriber
 
             }
         }
+    }
+
+    /**
+     * Adds token to current slug
+     * 
+     * @param string $slug
+     * @param mixed  $token
+     * @param array  $options
+     *
+     * @return string Updated token
+     */
+    private function addSlugToken($slug, $token, array $options)
+    {
+        $slug .= ($token instanceof \DateTime) ? $token->format($options['dateFormat']) : $token;
+        $slug .= ' ';
+
+        return $slug;
     }
 
     /**

--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -92,7 +92,8 @@
     <xs:sequence>
       <xs:element name="handler" type="gedmo:handler" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="fields" type="xs:string" use="required"/>
+    <xs:attribute name="fields" type="xs:string" use="optional"/>
+    <xs:attribute name="callback" type="xs:string" use="optional"/>
     <xs:attribute name="unique" type="xs:boolean" use="optional" />
     <xs:attribute name="unique-base" type="xs:string" use="optional" />
     <xs:attribute name="updatable" type="xs:boolean" use="optional" />

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.Sluggable.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.Sluggable.dcm.xml
@@ -26,5 +26,9 @@
         <many-to-one field="parent" target-entity="Sluggable">
             <join-column name="parent_id" referenced-column-name="id" on-delete="CASCADE"/>
         </many-to-one>
+
+        <field name="slugWithCallback" type="string" length="256" unique="true">
+            <gedmo:slug callback="getSlugTokens" />
+        </field>
     </entity>
 </doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml
@@ -38,6 +38,12 @@ Mapping\Fixture\Yaml\Category:
             "Gedmo\Sluggable\Handler\TreeSlugHandler":
               parentRelationField: parent
               separator: /
+    slugWithCallback:
+      type: string
+      length: 256
+      gedmo:
+        slug:
+          callback: "getSlugTokens"
     changed:
       type: date
       gedmo:

--- a/tests/Gedmo/Mapping/Fixture/Xml/Sluggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/Sluggable.php
@@ -15,4 +15,6 @@ class Sluggable
     private $slug;
 
     private $parent;
+
+    private $slugWithCallback;
 }

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Category.php
@@ -33,6 +33,13 @@ class Category extends BaseCategory
     private $slug;
 
     /**
+     * @var string $slugWithCallback
+     *
+     * @Column(name="slug_with_callback", type="string", length=256)
+     */
+    private $slugWithCallback;
+
+    /**
      * @var Entity\Category
      *
      * @OneToMany(targetEntity="Category", mappedBy="parent")
@@ -99,6 +106,26 @@ class Category extends BaseCategory
     public function getSlug()
     {
         return $this->slug;
+    }
+
+    /**
+     * Set slug with callback
+     *
+     * @param string $slugWithCallback
+     */
+    public function setSlugWithCallback($slugWithCallback)
+    {
+        $this->slugWithCallback = $slugWithCallback;
+    }
+
+    /**
+     * Get slug with callback
+     *
+     * @return string
+     */
+    public function getSlugWithCallback()
+    {
+        return $this->slugWithCallback;
     }
 
     /**

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -102,6 +102,11 @@ class SluggableMappingTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('parent', $second['relationField']);
         $this->assertEquals('slug', $second['relationSlugField']);
         $this->assertEquals('/', $second['separator']);
+
+        // Callback slug
+        $this->assertEquals('slugWithCallback', $config['slugs']['slugWithCallback']['slug']);
+        $this->assertArrayHasKey('callback', $config['slugs']['slugWithCallback']);
+        $this->assertEquals('getSlugTokens', $config['slugs']['slugWithCallback']['callback']);
     }
 
     /**

--- a/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/SluggableMappingTest.php
@@ -57,7 +57,9 @@ class SluggableMappingTest extends BaseTestCaseORM
         $config = $this->sluggable->getConfiguration($this->em, $meta->name);
 
         $this->assertArrayHasKey('slug', $config['slugs']);
-        $this->assertCount(1, $config['slugs']);
+        $this->assertCount(2, $config['slugs']);
+        
+        $callbackConfig = $config['slugs']['slugWithCallback'];
         $config = $config['slugs']['slug'];
 
         $this->assertEquals('slug', $config['slug']);
@@ -100,5 +102,10 @@ class SluggableMappingTest extends BaseTestCaseORM
         $this->assertEquals('parent', $second['relationField']);
         $this->assertEquals('test', $second['relationSlugField']);
         $this->assertEquals('-', $second['separator']);
+
+        // Callback slug
+        $this->assertEquals('slugWithCallback', $callbackConfig['slug']);
+        $this->assertArrayHasKey('callback', $callbackConfig);
+        $this->assertEquals('getSlugTokens', $callbackConfig['callback']);
     }
 }

--- a/tests/Gedmo/Sluggable/Fixture/CallbackSlug.php
+++ b/tests/Gedmo/Sluggable/Fixture/CallbackSlug.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Sluggable\Fixture;
+
+use Gedmo\Sluggable\Sluggable;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CallbackSlug implements Sluggable
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @ORM\Column(name="code", type="string", length=16)
+     */
+    private $code;
+
+    /**
+     * @Gedmo\Slug(separator="-", updatable=true, callback="getSlugTokens")
+     * @ORM\Column(name="slug", type="string", length=64, unique=true)
+     */
+    private $slug;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+    }
+
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+
+    public function getSlugTokens()
+    {
+        return [
+            $this->getTitle(),
+            $this->getCode(),
+        ];
+    }
+}

--- a/tests/Gedmo/Sluggable/SluggableCallbackTest.php
+++ b/tests/Gedmo/Sluggable/SluggableCallbackTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Gedmo\Sluggable;
+
+use Doctrine\Common\EventManager;
+use Sluggable\Fixture\CallbackSlug;
+use Tool\BaseTestCaseORM;
+
+class SluggableCallbackTest extends BaseTestCaseORM
+{
+    const ARTICLE = 'Sluggable\\Fixture\\CallbackSlug';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new SluggableListener());
+
+        $this->getMockSqliteEntityManager($evm);
+    }
+
+    /**
+     * @test
+     */
+    public function testCallbackSlug()
+    {
+        $article = new CallbackSlug();
+        $article->setTitle('the title');
+        $article->setCode('my code');
+        
+        $this->em->persist($article);
+        $this->em->flush();
+
+        $this->assertEquals('the-title-my-code', $article->getSlug());
+    }
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            self::ARTICLE,
+        );
+    }
+}


### PR DESCRIPTION
Hello!

This PR introduces a new `callback` option for the Sluggable behavior. It looks quite big in the code, but is actually quite simple.

The purpose of this addition is two-fold:

* It allows more than one relative handlers.
* It is simpler to use than the `RelativeSlugHandler` if there is no need for the `InversedRelativeSlugHandler`.

It can be used instead of the usual `fields` option to define a callback on the current object that will return the slug tokens.
The `fields` option is therefore not required anymore (either `fields` or `callback` is now required).

It is currently not possible to define multiple relative handlers, for generating a slug with a structure like `<category>-<brand>-<model>` (where the category and the brand are relationships to the current entity).

A question was raised on StackOverflow about it: http://stackoverflow.com/questions/37397975/multiple-relativeslughandler

The feature introduced in this PR can handle this, like in this example:

```php
<?php
class Product
{
    /**
     * @ORM\ManyToOne(targetEntity="Category")
     */
    protected $category;
    
    /**
     * @ORM\ManyToOne(targetEntity="Brand")
     */
    protected $brand;
    
    /**
     * @ORM\Column(name="model", type="string", length=128)
     */
    protected $model;

    /**
     * @Gedmo\Slug(callback="getSlugTokens")
     */
    protected $slug;

    public function getBrand()
    {
        return $this->getBrand();
    }

    public function getCategory()
    {
        return $this->getCategory();
    }

    public function getModel()
    {
        return $this->getModel();
    }

    public function getSlugTokens()
    {
        return [
            $this->getCategory()->getName(),
            $this->getBrand()->getName(),
            $this->getModel(),
        ];
    }
}
```

This doesn't replace the `RelativeSlugHandler` as the there is no counterpart for the
`InversedRelativeSlugHandler`.
But it is really useful for getting tokens to generate a slug, be it for relationships
or other kind of data.

I hope you like this idea! I'm open to any suggestion for improving it :)
