### PR TITLE
[Sluggable] Fix query when identifier is a embedded value holder

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -62,8 +62,9 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
         // include identifiers
         foreach ((array) $wrapped->getIdentifier(false) as $id => $value) {
             if (!$meta->isIdentifier($config['slug'])) {
-                $qb->andWhere($qb->expr()->neq('rec.'.$id, ':'.$id));
-                $qb->setParameter($id, $value);
+                $namedId = str_replace('.', '_', $id);
+                $qb->andWhere($qb->expr()->neq('rec.'.$id, ':'.$namedId));
+                $qb->setParameter($namedId, $value);
             }
         }
         $q = $qb->getQuery();


### PR DESCRIPTION
We use a value holder class as one of our entities `identifiers` and this generates a problem when finding the unique value of a slug. The ORM class generates a SQL statement to find al Similar slugs. But then it try's to generate a named variable with a . inside of it and that is not allowed by doctrine. 

```
SELECT rec.slug FROM CoreDomain\Category\Category rec WHERE rec.slug LIKE :slug AND rec.id.uuid <> :id.uuid
``` 

```php
class Category
{
    /**
     * @var CategoryId
     *
     * @ORM\Embedded(class="CoreDomain\Category\CategoryId", columnPrefix=false)
     */
    private $id;
}
```

```php
/**
 * @ORM\Embeddable
 */
final class CategoryId
{
    /**
     * @var UuidInterface
     *
     * @ORM\Id
     * @ORM\Column(type="uuid")
     */
    private $uuid;
}
```

![error](https://cloud.githubusercontent.com/assets/771041/22887185/5b2d00dc-f201-11e6-9d59-7029c773b84b.png)
