### PR TITLE
Remove unnecessary variable from example

### DIFF
--- a/example/run.php
+++ b/example/run.php
@@ -13,7 +13,6 @@ $em = include 'em.php';
  *
  * Gedmo\Translatable\TranslationListener
  */
-$translatable;
 
 $repository = $em->getRepository('Entity\Category');
 $food = $repository->findOneByTitle('Food');


### PR DESCRIPTION
Undeclared variable `$translatable;` in the code does nothing.