### PR TITLE
[SoftDeleteable] Easily allow users to perform selects of ONLY soft deleted entities.

### DIFF
--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -11,6 +11,7 @@ Features:
 - Can be nested with other behaviors
 - Annotation, Yaml and Xml mapping support for extensions
 - Support for 'timeAware' option: When creating an entity set a date of deletion in the future and never worry about cleaning up at expiration time.
+- Support for **only** selecting **soft deleted** entries by swapping from the `SoftDeleteable` filter to the `SoftDeleted` filter.
 
 Content:
 

--- a/lib/Gedmo/SoftDeleteable/Filter/AbstractFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/AbstractFilter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Gedmo\SoftDeleteable\Filter;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use Gedmo\SoftDeleteable\SoftDeleteableListener;
+
+/**
+ * The SoftDeleteableFilter adds the condition necessary to
+ * filter entities which were deleted "softly"
+ *
+ * @author Gustavo Falco <comfortablynumb84@gmail.com>
+ * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
+ * @author Patrik Votoček <patrik@votocek.cz>
+ * @author malc0mn <malc0mn@advalvas.be>
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+abstract class AbstractFilter extends SQLFilter
+{
+    /**
+     * @var SoftDeleteableListener
+     */
+    protected $listener;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * @var string[bool]
+     */
+    protected $disabled = array();
+
+    /**
+     * @var Connection
+     */
+    protected $conn;
+
+    /**
+     * @var AbstractPlatform
+     */
+    protected $platform;
+
+    /**
+     * @param ClassMetadata $targetEntity
+     *
+     * @return string|array
+     */
+    protected function getConfig(ClassMetadata $targetEntity)
+    {
+        $class = $targetEntity->getName();
+        if (array_key_exists($class, $this->disabled) && $this->disabled[$class] === true) {
+            return false;
+        } elseif (array_key_exists($targetEntity->rootEntityName, $this->disabled) && $this->disabled[$targetEntity->rootEntityName] === true) {
+            return false;
+        }
+
+        $config = $this->getListener()->getConfiguration($this->getEntityManager(), $targetEntity->name);
+
+        if (!isset($config['softDeleteable']) || !$config['softDeleteable']) {
+            return false;
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return string
+     */
+    protected function getColumn(ClassMetadata $targetEntity, array $config)
+    {
+        $this->conn = $this->getEntityManager()->getConnection();
+        $this->platform = $this->conn->getDatabasePlatform();
+        return $targetEntity->getQuotedColumnName($config['fieldName'], $this->platform);
+    }
+
+    /**
+     * @param string $class
+     */
+    public function disableForEntity($class)
+    {
+        $this->disabled[$class] = true;
+    }
+
+    /**
+     * @param string $class
+     */
+    public function enableForEntity($class)
+    {
+        $this->disabled[$class] = false;
+    }
+
+    /**
+     * @return SoftDeleteableListener
+     * @throws \RuntimeException
+     */
+    protected function getListener()
+    {
+        if ($this->listener === null) {
+            $em = $this->getEntityManager();
+            $evm = $em->getEventManager();
+
+            foreach ($evm->getListeners() as $listeners) {
+                foreach ($listeners as $listener) {
+                    if ($listener instanceof SoftDeleteableListener) {
+                        $this->listener = $listener;
+
+                        break 2;
+                    }
+                }
+            }
+
+            if ($this->listener === null) {
+                throw new \RuntimeException('Listener "SoftDeleteableListener" was not added to the EventManager!');
+            }
+        }
+
+        return $this->listener;
+    }
+
+    /**
+     * @return EntityManagerInterface
+     */
+    protected function getEntityManager()
+    {
+        if ($this->entityManager === null) {
+            $refl = new \ReflectionProperty('Doctrine\ORM\Query\Filter\SQLFilter', 'em');
+            $refl->setAccessible(true);
+            $this->entityManager = $refl->getValue($this);
+        }
+
+        return $this->entityManager;
+    }
+}

--- a/lib/Gedmo/SoftDeleteable/Filter/SoftDeletedFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/SoftDeletedFilter.php
@@ -5,8 +5,8 @@ namespace Gedmo\SoftDeleteable\Filter;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
- * The SoftDeleteableFilter adds the condition necessary to
- * filter entities which were deleted "softly"
+ * The SoftDeletedFilter adds the condition necessary to
+ * only select entities which were deleted "softly"
  *
  * @author Gustavo Falco <comfortablynumb84@gmail.com>
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
@@ -15,7 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-class SoftDeleteableFilter extends AbstractFilter
+class SoftDeletedFilter extends AbstractFilter
 {
     /**
      * @param ClassMetadata $targetEntity
@@ -30,10 +30,10 @@ class SoftDeleteableFilter extends AbstractFilter
 
         $column = $this->getColumn($targetEntity, $config);
 
-        $addCondSql = $this->platform->getIsNullExpression($targetTableAlias.'.'.$column);
+        $addCondSql = $this->platform->getIsNotNullExpression($targetTableAlias.'.'.$column);
         if (isset($config['timeAware']) && $config['timeAware']) {
             $now = $this->conn->quote(date($this->platform->getDateTimeFormatString())); // should use UTC in database and PHP
-            $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$now})";
+            $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} < {$now})";
         }
 
         return $addCondSql;


### PR DESCRIPTION
Added a **MySQL** filter `SoftDeleted` that does the exact opposite of the `SoftDeleteable` filter: it only selects soft deleted entries!

This is useful to build admin only views in applications so that admins can actually see all data ;-)

Needed this for an app I'm building and it seems generic enough to add as a feature to the SoftDeleable behavior.

This one is only for SQL though... Should be easy enough to port to MongoDB