### PR TITLE
bug with entity column naming

### DIFF
--- a/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
@@ -16,14 +16,14 @@ trait TimestampableEntity
     /**
      * @var \DateTime
      * @Gedmo\Timestampable(on="create")
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(name="created_at", type="datetime")
      */
     protected $createdAt;
 
     /**
      * @var \DateTime
      * @Gedmo\Timestampable(on="update")
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(name="updated_at", type="datetime")
      */
     protected $updatedAt;
 


### PR DESCRIPTION
An exception occurred while executing 'INSERT INTO application (id, identifier, status, type, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?)' with params [9, "2212", "\u041d\u043e\u0432\u044b\u0439", "\u041a\u0440\u0435\u0434\u0438\u0442", "2017-03-17 18:48:18", "2017-03-17 18:48:18"]:
ORA-00904: "CREATEDAT": invalid identifier"