### PR TITLE
Made exception more helpful

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Mapping/Validator.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Validator.php
@@ -38,9 +38,11 @@ class Validator
         $fieldMapping = $meta->getFieldMapping($field);
 
         if (!in_array($fieldMapping['type'], self::$validTypes)) {
-            throw new InvalidMappingException(sprintf('Field "%s" must be of one of the following types: "%s"',
+            throw new InvalidMappingException(sprintf('Field "%s" (type "%s") must be of one of the following types: "%s" in entity %s',
+                $field,
                 $fieldMapping['type'],
-                implode(', ', self::$validTypes)));
+                implode(', ', self::$validTypes),
+                $meta->name));
         }
     }
 }


### PR DESCRIPTION
The exception did not provide adequate context for chasing down the root cause of the error. By adding the field name and affected entity, locating the issue is considerably easier.