### PR TITLE
Fix string length for unique indexes on utf8mb4 MySQL collation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "behat/transliterator": "~1.0",
+        "behat/transliterator": "1.1",
         "doctrine/common": "~2.4"
     },
     "require-dev": {

--- a/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/lib/Gedmo/Loggable/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -44,7 +44,7 @@ abstract class AbstractLogEntry
     /**
      * @var string $objectClass
      *
-     * @ORM\Column(name="object_class", type="string", length=255)
+     * @ORM\Column(name="object_class", type="string", length=191)
      */
     protected $objectClass;
 
@@ -65,7 +65,7 @@ abstract class AbstractLogEntry
     /**
      * @var string $data
      *
-     * @ORM\Column(length=255, nullable=true)
+     * @ORM\Column(length=191, nullable=true)
      */
     protected $username;
 

--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
@@ -30,7 +30,7 @@ abstract class AbstractTranslation
     /**
      * @var string $objectClass
      *
-     * @ORM\Column(name="object_class", type="string", length=255)
+     * @ORM\Column(name="object_class", type="string", length=191)
      */
     protected $objectClass;
 


### PR DESCRIPTION
Updated the string length to make it compatible with utf8mb4 which is now Symfony best practice as per the best practice guide. [Friends Of Symfony](https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2182) are also updating their extensions for compatibility.

