### PR TITLE
Removed from duplicate root declaration.

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -248,11 +248,6 @@ Entity\Category:
       type: integer
       gedmo:
         - treeRight
-    root:
-      type: integer
-      nullable: true
-      gedmo:
-        - treeRoot
     lvl:
       type: integer
       gedmo:


### PR DESCRIPTION
Related with https://github.com/Atlantic18/DoctrineExtensions/issues/1710#issuecomment-292451603 issue.
The root field is declared twice, on fields and manyToOne secction.