### PR TITLE
fix tree hydrator proxy

### DIFF
--- a/lib/Gedmo/Tree/Hydrator/ORM/TreeObjectHydrator.php
+++ b/lib/Gedmo/Tree/Hydrator/ORM/TreeObjectHydrator.php
@@ -248,7 +248,7 @@ class TreeObjectHydrator extends ObjectHydrator
     {
         $firstMappedEntity = array_values($data);
         $firstMappedEntity = $firstMappedEntity[0];
-        return get_class($firstMappedEntity);
+        return $this->_em->getClassMetadata(get_class($firstMappedEntity))->rootEntityName;
     }
 
     protected function getPropertyValue($object, $property)


### PR DESCRIPTION
Hey, when calling hydrator multiple times, sometimes there r proxy classes in [data](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/lib/Gedmo/Tree/Hydrator/ORM/TreeObjectHydrator.php#L56). When this happens [getConfiguration](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/lib/Gedmo/Tree/Hydrator/ORM/TreeObjectHydrator.php#L57) returns empty array and hydrator throw 'The `parent` property is required for the TreeHydrator to work'. I made minor fix for this issue. Please let me know if u have any questions.