### PR TITLE
[Loggable] Allow for Embedded documents to also have child documents

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -128,7 +128,12 @@ class Annotation extends AbstractAnnotationDriver
         foreach ($сlass->getProperties() as $property) {
             // versioned property
             if ($this->reader->getPropertyAnnotation($property, self::VERSIONED)) {
-                $config['versioned'][] = $field . '.' . $property->getName();
+                $embeddedField = $field . '.' . $property->getName();
+                $config['versioned'][] = $embeddedField;
+
+                if (isset($meta->embeddedClasses[$embeddedField])) {
+                    $this->inspectEmbeddedForVersioned($embeddedField, $config, $meta);
+                }
             }
         }
     }

--- a/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Geo.php
@@ -29,14 +29,24 @@ class Geo
     protected $longitude;
 
     /**
-     * Geo constructor.
-     * @param string $latitude
-     * @param string $longitude
+     * @var GeoLocation $geoLocation
+     * @ORM\Embedded(class="Loggable\Fixture\Entity\GeoLocation")
+     * @Gedmo\Versioned()
      */
-    public function __construct($latitude, $longitude)
+    protected $geoLocation;
+
+    /**
+     * Geo constructor.
+     *
+     * @param string      $latitude
+     * @param string      $longitude
+     * @param GeoLocation $geoLocation
+     */
+    public function __construct($latitude, $longitude, GeoLocation $geoLocation)
     {
         $this->latitude = $latitude;
         $this->longitude = $longitude;
+        $this->geoLocation = $geoLocation;
     }
 
     /**
@@ -69,5 +79,21 @@ class Geo
     public function setLongitude($longitude)
     {
         $this->longitude = $longitude;
+    }
+
+    /**
+     * @return GeoLocation
+     */
+    public function getGeoLocation()
+    {
+        return $this->geoLocation;
+    }
+
+    /**
+     * @param GeoLocation $geoLocation
+     */
+    public function setGeoLocation($geoLocation)
+    {
+        $this->geoLocation = $geoLocation;
     }
 }

--- a/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/GeoLocation.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Loggable\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * Class GeoLocation
+ * @package Loggable\Fixture
+ * @author Fabian Sabau <fabian.sabau@socialbit.de>
+ *
+ * @ORM\Embeddable()
+ */
+class GeoLocation
+{
+    /**
+     * @var string $latitude
+     * @ORM\Column(type="string")
+     * @Gedmo\Versioned()
+     */
+    protected $location;
+
+    /**
+     * Geo constructor.
+     * @param string $location
+     */
+    public function __construct($location)
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param string $location
+     */
+    public function setLocation($location)
+    {
+        $this->location = $location;
+    }
+}

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Loggable;
 
+use Loggable\Fixture\Entity\GeoLocation;
 use Tool\BaseTestCaseORM;
 use Doctrine\Common\EventManager;
 use Loggable\Fixture\Entity\Address;
@@ -144,7 +145,10 @@ class LoggableEntityTest extends BaseTestCaseORM
         $logEntries = $logRepo->getLogEntries($address);
 
         $this->assertCount(4, $logEntries);
-
+        $this->assertCount(1, $logEntries[0]->getData());
+        $this->assertCount(2, $logEntries[1]->getData());
+        $this->assertCount(3, $logEntries[2]->getData());
+        $this->assertCount(5, $logEntries[3]->getData());
     }
 
     protected function getUsedEntityFixtures()
@@ -166,14 +170,14 @@ class LoggableEntityTest extends BaseTestCaseORM
         $address->setCity('city-v1');
         $address->setStreet('street-v1');
 
-        $geo = new Geo(1.0000, 1.0000);
+        $geo = new Geo(1.0000, 1.0000, new GeoLocation('Online'));
 
         $address->setGeo($geo);
 
         $this->em->persist($address);
         $this->em->flush();
 
-        $geo2 = new Geo(2.0000, 2.0000);
+        $geo2 = new Geo(2.0000, 2.0000, new GeoLocation('Offline'));
         $address->setGeo($geo2);
 
         $this->em->persist($address);


### PR DESCRIPTION
In the current implementation if a embedded class has  child embedded class the fields for this child's do not get logged. This is solving that problem. I'm not sure how to update and test the other mappings here. 