### PR TITLE
Change links in documentation to point to this repository

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -63,7 +63,7 @@ New annotation reader does not depend on any namespaces, for that reason you can
 single reader instance for whole project. The example bellow shows how to setup the
 mapping and listeners:
 
-**Note:** using this repository you can test and check the [example demo configuration](https://github.com/l3pp4rd/DoctrineExtensions/blob/master/example/em.php)
+**Note:** using this repository you can test and check the [example demo configuration](https://github.com/Atlantic18/DoctrineExtensions/blob/master/example/em.php)
 
 ``` php
 <?php
@@ -564,4 +564,3 @@ private $content;
  */
 private $article;
 ```
-

--- a/doc/blameable.md
+++ b/doc/blameable.md
@@ -46,8 +46,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -642,4 +642,3 @@ class UsingTrait
 
 The Traits are very simplistic - if you use different field names it is recommended to simply create your
 own Traits specific to your project. The ones provided by this bundle can be used as example.
-

--- a/doc/ip_traceable.md
+++ b/doc/ip_traceable.md
@@ -41,8 +41,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -603,12 +603,12 @@ class IpTraceSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // If you use a cache like Varnish, you may want to set a proxy to Request::getClientIp() method 
+        // If you use a cache like Varnish, you may want to set a proxy to Request::getClientIp() method
         // $this->request->setTrustedProxies(array('127.0.0.1'));
 
         // $ip = $_SERVER['REMOTE_ADDR'];
         $ip = $this->request->getClientIp();
-        
+
         if (null !== $ip) {
             $this->ipTraceableListener->setIpValue($ip);
         }
@@ -638,7 +638,7 @@ class IpTraceSubscriber implements EventSubscriberInterface
     </parameters>
 
     <services>
-        
+
         ...
 
         <service id="gedmo_doctrine_extensions.listener.ip_traceable" class="Gedmo\IpTraceable\IpTraceableListener" public="false">

--- a/doc/loggable.md
+++ b/doc/loggable.md
@@ -37,8 +37,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 ### Loggable annotations:

--- a/doc/mapping.md
+++ b/doc/mapping.md
@@ -11,7 +11,7 @@ Features:
 - Mapping drivers for annotation and yaml
 - Conventional extension points for metadata extraction and object manager abstraction
 
-- Public [Mapping repository](http://github.com/l3pp4rd/DoctrineExtensions "Mapping extension on Github") is available on github
+- Public [Mapping repository](http://github.com/Atlantic18/DoctrineExtensions "Mapping extension on Github") is available on github
 - Last update date: **2012-01-02**
 
 This article will cover the basic installation and usage of **Mapping** extension
@@ -31,8 +31,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="create-extension"></a>

--- a/doc/reference_integrity.md
+++ b/doc/reference_integrity.md
@@ -36,8 +36,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="document-mapping"></a>

--- a/doc/sluggable.md
+++ b/doc/sluggable.md
@@ -55,10 +55,10 @@ no more exceptions during concurrent flushes.
 
 **Note:**
 
-- There is a reported [issue](https://github.com/l3pp4rd/DoctrineExtensions/issues/254) that sluggable transliterator
+- There is a reported [issue](https://github.com/Atlantic18/DoctrineExtensions/issues/254) that sluggable transliterator
 does not work on OSX 10.6 its ok starting again from 10.7 version. To overcome the problem
 you can use your [custom transliterator](#transliterator)
-- Public [Sluggable repository](http://github.com/l3pp4rd/DoctrineExtensions "Sluggable extension on Github") is available on github
+- Public [Sluggable repository](http://github.com/Atlantic18/DoctrineExtensions "Sluggable extension on Github") is available on github
 - Last update date: **2012-02-26**
 - For usage together with **SoftDeleteable** in order to take into account softdeleted entities while generating unique
 slug, you must explicitly call **addManagedFilter** with a name of softdeleteable filter, so it can be disabled during
@@ -88,8 +88,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -779,7 +779,7 @@ class Company
 ```
 
 For other mapping drivers see
-[xml](https://github.com/l3pp4rd/DoctrineExtensions/blob/master/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.Sluggable.dcm.xml) or [yaml](https://github.com/l3pp4rd/DoctrineExtensions/blob/master/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml) examples from tests
+[xml](https://github.com/Atlantic18/DoctrineExtensions/blob/master/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.Sluggable.dcm.xml) or [yaml](https://github.com/Atlantic18/DoctrineExtensions/blob/master/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Category.dcm.yml) examples from tests
 
 And the example usage:
 

--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -25,8 +25,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 With SoftDeleteable there's one more step you need to do. You need to add the filter to your configuration:

--- a/doc/sortable.md
+++ b/doc/sortable.md
@@ -12,7 +12,7 @@ Features:
 
 **Note:**
 
-- Public [Sortable repository](http://github.com/l3pp4rd/DoctrineExtensions "Sortable extension on Github") is available on github
+- Public [Sortable repository](http://github.com/Atlantic18/DoctrineExtensions "Sortable extension on Github") is available on github
 - Last update date: **2012-01-02**
 
 **Portability:**
@@ -30,15 +30,15 @@ Content:
 - [Yaml](#yaml-mapping) mapping example
 - [Xml](#xml-mapping) mapping example
 - Basic usage [examples](#basic-examples)
-- Custom comparison [method](#custom-comparisons) 
+- Custom comparison [method](#custom-comparisons)
 
 
 <a name="including-extension"></a>
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -319,9 +319,9 @@ class Item implements Comparable
     public function compareTo($other)
     {
         // return 1 if this object is considered greater than the compare value
-        
+
         // return -1 if this object is considered less than the compare value
-        
+
         // return 0 if this object is considered equal to the compare value
     }
 }

--- a/doc/symfony2.md
+++ b/doc/symfony2.md
@@ -1,6 +1,6 @@
 # Install Gedmo Doctrine2 extensions in Symfony2
 
-Configure full featured [Doctrine2 extensions](http://github.com/l3pp4rd/DoctrineExtensions) for your symfony2 project.
+Configure full featured [Doctrine2 extensions](http://github.com/Atlantic18/DoctrineExtensions) for your symfony2 project.
 This post will show you - how to create a simple configuration file to manage extensions with
 ability to use all features it provides.
 Interested? then bear with me! and don't be afraid, we're not diving into security component :)
@@ -218,14 +218,14 @@ services:
             - { name: doctrine.event_subscriber, connection: default }
         calls:
             - [ setAnnotationReader, [ "@annotation_reader" ] ]
-            
+
     gedmo.listener.blameable:
         class: Gedmo\Blameable\BlameableListener
         tags:
             - { name: doctrine.event_subscriber, connection: default }
         calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]            
-            
+            - [ setAnnotationReader, [ "@annotation_reader" ] ]
+
 ```
 
 So what does it include in general? Well, it creates services for all extension listeners.
@@ -266,7 +266,7 @@ class DoctrineExtensionListener implements ContainerAwareInterface
         $translatable = $this->container->get('gedmo.listener.translatable');
         $translatable->setTranslatableLocale($event->getRequest()->getLocale());
     }
-    
+
     public function onConsoleCommand()
     {
         $this->container->get('gedmo.listener.translatable')
@@ -281,7 +281,7 @@ class DoctrineExtensionListener implements ContainerAwareInterface
                 # for loggable behavior
                 $loggable = $this->container->get('gedmo.listener.loggable');
                 $loggable->setUsername($securityContext->getToken()->getUsername());
-                
+
                 # for blameable behavior
                 $blameable = $this->container->get('gedmo.listener.blameable');
                 $blameable->setUserValue($securityContext->getToken()->getUser());
@@ -294,7 +294,7 @@ class DoctrineExtensionListener implements ContainerAwareInterface
                 # for loggable behavior
                 $loggable = $this->container->get('gedmo.listener.loggable');
                 $loggable->setUsername($tokenStorage->getUser());
-                
+
                 # for blameable behavior
                 $blameable = $this->container->get('gedmo.listener.blameable');
                 $blameable->setUserValue($tokenStorage->getUser());
@@ -485,8 +485,8 @@ doctrine_mongodb:
 This also shows, how to make mappings based on single manager. All what differs is that **Document**
 instead of **Entity** is used. I haven't tested it with mongo though.
 
-**Note:** [extension repository](http://github.com/l3pp4rd/DoctrineExtensions) contains all
-[documentation](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/doc) you may need
+**Note:** [extension repository](http://github.com/Atlantic18/DoctrineExtensions) contains all
+[documentation](http://github.com/Atlantic18/DoctrineExtensions/tree/master/doc) you may need
 to understand how you can use it in your projects.
 
 <a name="alternative"></a>

--- a/doc/timestampable.md
+++ b/doc/timestampable.md
@@ -50,8 +50,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 <a name="entity-mapping"></a>
@@ -672,4 +672,3 @@ class UsingTrait
 
 Traits are very simple and if you use different field names I recommend to simply create your
 own ones based per project. These ones are standing as an example.
-

--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -22,7 +22,7 @@ constraint. This dramatically improves the management of translations
 **2012-01-04**
 
 - Refactored translatable to be able to persist, update many translations
-using repository, [issue #224](https://github.com/l3pp4rd/DoctrineExtensions/issues/224)
+using repository, [issue #224](https://github.com/Atlantic18/DoctrineExtensions/issues/224)
 
 **2011-12-11**
 
@@ -54,7 +54,7 @@ and any number of them
 
 **Note list:**
 
-- Public [Translatable repository](http://github.com/l3pp4rd/DoctrineExtensions "Translatable extension on Github") is available on github
+- Public [Translatable repository](http://github.com/Atlantic18/DoctrineExtensions "Translatable extension on Github") is available on github
 - Using other extensions on the same Entity fields may result in unexpected way
 - May impact your application performance since it does an additional query for translation if loaded without query hint
 - Last update date: **2012-02-15**
@@ -83,8 +83,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in most optimized way.
 
 ### Translatable annotations:

--- a/doc/tree.md
+++ b/doc/tree.md
@@ -62,7 +62,7 @@ Update **2011-02-02**
 - After using a NestedTreeRepository functions: **verify, recover, removeFromTree** it is recommended to clear the EntityManager cache
 because nodes may have changed values in database but not in memory. Flushing dirty nodes can lead to unexpected behaviour.
 - Closure tree implementation is experimental and not fully functional, so far not documented either
-- Public [Tree repository](http://github.com/l3pp4rd/DoctrineExtensions "Tree extension on Github") is available on github
+- Public [Tree repository](http://github.com/Atlantic18/DoctrineExtensions "Tree extension on Github") is available on github
 - Last update date: **2012-02-23**
 
 **Portability:**
@@ -90,8 +90,8 @@ Content:
 
 ## Setup and autoloading
 
-Read the [documentation](http://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
-or check the [example code](http://github.com/l3pp4rd/DoctrineExtensions/tree/master/example)
+Read the [documentation](http://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md#em-setup)
+or check the [example code](http://github.com/Atlantic18/DoctrineExtensions/tree/master/example)
 on how to setup and use the extensions in the most optimized way.
 
 <a name="entity-mapping"></a>


### PR DESCRIPTION
Hi.

The links in documentation pointed to the old repository at https://github.com/l3pp4rd/DoctrineExtensions/

This patch fixes the links to point to this repo.