### PR TITLE
Ignore tests on git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore


### PR DESCRIPTION
This prevents composer downloading the lib's test suite on dependent projects.