### PR TITLE
Substitute Date annotation with Field(type="date")

### DIFF
--- a/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableDocument.php
@@ -16,14 +16,14 @@ trait TimestampableDocument
     /**
      * @var \DateTime
      * @Gedmo\Timestampable(on="create")
-     * @ODM\Date
+     * @ODM\Field(type="date")
      */
     protected $createdAt;
 
     /**
      * @var \DateTime
      * @Gedmo\Timestampable(on="update")
-     * @ODM\Date
+     * @ODM\Field(type="date")
      */
     protected $updatedAt;
 


### PR DESCRIPTION
User Deprecated: Doctrine\ODM\MongoDB\Mapping\Annotations\Date will be removed in ODM 2.0. Use `@ODM\Field(type="date")` instead.