### PR TITLE
[Loggable] ODM query performance fix using compound index

### DIFF
--- a/lib/Gedmo/Loggable/Document/LogEntry.php
+++ b/lib/Gedmo/Loggable/Document/LogEntry.php
@@ -2,12 +2,20 @@
 
 namespace Gedmo\Loggable\Document;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoODM;
 
 /**
  * Gedmo\Loggable\Document\LogEntry
  *
- * @Document(repositoryClass="Gedmo\Loggable\Document\Repository\LogEntryRepository")
+ * @MongoODM\Document(
+ *     repositoryClass="Gedmo\Loggable\Document\Repository\LogEntryRepository",
+ *     indexes={
+ *         @MongoODM\Index(keys={"objectId"="asc", "objectClass"="asc", "version"="asc"}),
+ *         @MongoODM\Index(keys={"loggedAt"="asc"}),
+ *         @MongoODM\Index(keys={"objectClass"="asc"}),
+ *         @MongoODM\Index(keys={"username"="asc"})
+ *     }
+ * )
  */
 class LogEntry extends MappedSuperclass\AbstractLogEntry
 {

--- a/lib/Gedmo/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
+++ b/lib/Gedmo/Loggable/Document/MappedSuperclass/AbstractLogEntry.php
@@ -28,7 +28,6 @@ abstract class AbstractLogEntry
     /**
      * @var \DateTime $loggedAt
      *
-     * @MongoODM\Index
      * @MongoODM\Field(type="date")
      */
     protected $loggedAt;
@@ -43,7 +42,6 @@ abstract class AbstractLogEntry
     /**
      * @var string $objectClass
      *
-     * @MongoODM\Index
      * @MongoODM\Field(type="string")
      */
     protected $objectClass;
@@ -65,7 +63,6 @@ abstract class AbstractLogEntry
     /**
      * @var string $data
      *
-     * @MongoODM\Index
      * @MongoODM\Field(type="string", nullable=true)
      */
     protected $username;


### PR DESCRIPTION
Adds a compound index to ODM `LogEntry`, to optimise query performance, especially for `getNewVersion` query.

Fixes https://github.com/Atlantic18/DoctrineExtensions/issues/1811