### PR TITLE
Translatable Mapping Adapter fix to be able to use second level cache for translations

### DIFF
--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractPersonalTranslation.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\MappedSuperclass
  */
-abstract class AbstractPersonalTranslation
+abstract class AbstractPersonalTranslation implements TranslationInterface
 {
     /**
      * @var integer $id

--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/AbstractTranslation.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\MappedSuperclass
  */
-abstract class AbstractTranslation
+abstract class AbstractTranslation implements TranslationInterface
 {
     /**
      * @var integer $id

--- a/lib/Gedmo/Translatable/Entity/MappedSuperclass/TranslationInterface.php
+++ b/lib/Gedmo/Translatable/Entity/MappedSuperclass/TranslationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Gedmo\Translatable\Entity\MappedSuperclass;
+
+
+interface TranslationInterface
+{
+    public function getField();
+    public function getContent();
+}

--- a/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
@@ -71,26 +71,19 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
             }
             // if collection is not set, fetch it through relation
             if (!$found) {
-                $dql = 'SELECT t.content, t.field FROM '.$translationClass.' t';
-                $dql .= ' WHERE t.locale = :locale';
-                $dql .= ' AND t.object = :object';
-
-                $q = $em->createQuery($dql);
-                $q->setParameters(compact('object', 'locale'));
-                $result = $q->getArrayResult();
+                $result = $em->getRepository($translationClass)->findBy([
+                    'locale' => $locale,
+                    'object' => $object
+                ]);
             }
         } else {
             // load translated content for all translatable fields
             $objectId = $this->foreignKey($wrapped->getIdentifier(), $translationClass);
-            // construct query
-            $dql = 'SELECT t.content, t.field FROM '.$translationClass.' t';
-            $dql .= ' WHERE t.foreignKey = :objectId';
-            $dql .= ' AND t.locale = :locale';
-            $dql .= ' AND t.objectClass = :objectClass';
-            // fetch results
-            $q = $em->createQuery($dql);
-            $q->setParameters(compact('objectId', 'locale', 'objectClass'));
-            $result = $q->getArrayResult();
+            $result = $em->getRepository($translationClass)->findBy([
+                'foreignKey' => $objectId,
+                'locale' => $locale,
+                'objectClass' => $objectClass
+            ]);
         }
 
         return $result;

--- a/lib/Gedmo/Translatable/TranslatableListener.php
+++ b/lib/Gedmo/Translatable/TranslatableListener.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 use Gedmo\Mapping\MappedEventSubscriber;
+use Gedmo\Translatable\Entity\MappedSuperclass\TranslationInterface;
 use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
 
 /**
@@ -473,6 +474,12 @@ class TranslatableListener extends MappedEventSubscriber
                 $translated = '';
                 $is_translated = false;
                 foreach ((array) $result as $entry) {
+                    if($entry instanceof TranslationInterface) {
+                       $entry = [
+                           'field' => $entry->getField(),
+                           'content' => $entry->getContent()
+                       ];
+                    }
                     if ($entry['field'] == $field) {
                         $translated = $entry['content'];
                         $is_translated = true;


### PR DESCRIPTION
There is one small problem with ORM Adapters under
lib/Gedmo/Translatable/Mapping/Event/Adapter
Custom queries does not support doctrine second level cache (needs object instead of array) 

http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/second-level-cache.html

With this fix you can create custom TranslationEntity which extends AbstractTranslation class add annotation and cache will work
>     cache:
>         usage : READ_ONLY
>         region : region_transaltions

**_My solution is not the best but it helps._**
