### PR TITLE
[fix/question] Add the call to the Doctrine UnitOfWork class 

### DIFF
--- a/lib/Gedmo/Mapping/Event/AdapterInterface.php
+++ b/lib/Gedmo/Mapping/Event/AdapterInterface.php
@@ -3,6 +3,7 @@
 namespace Gedmo\Mapping\Event;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\ORM\UnitOfWork;
 
 /**
  * Doctrine event adapter interface is used


### PR DESCRIPTION
Why does we not have an `use Doctrine\ORM\UnitOfWork;` call in this class ? 

The UnitOfWork object is used as parameter in many methods of this class