### PR TITLE
Always passes string as object ID for optimization

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -56,7 +56,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.objectClass = :objectClass";
         $dql .= " ORDER BY log.version DESC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass'));
 
@@ -88,7 +88,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.version <= :version";
         $dql .= " ORDER BY log.version ASC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass', 'version'));
         $logs = $q->getResult();


### PR DESCRIPTION
Identifier of entity in most of the cases is integer ID. In these cases, if integer is passed to the query, database cannot use indexes as it has to convert `objectId` value of every row to integer before comparing. As `objectId` is `VARCHAR`/`string`, we should always compare it to another string.

For example, in the project I'm working on:

```sql
EXPLAIN SELECT * FROM ext_log_entries e0_
WHERE e0_.object_id = 123 AND e0_.object_class = 'Entity'
ORDER BY e0_.version DESC;
```

```
1	SIMPLE	e0_	ref	log_class_lookup_idx	log_class_lookup_idx	767	const	2135034	Using where; Using filesort
```

If `123` is changed to `'123'` in the query, we get:

```
1	SIMPLE	e0_	ref	log_class_lookup_idx	log_class_lookup_idx	866	const,const	6	Using where; Using filesort
```