### PR TITLE
Tests: remove manual env checks, update PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
         - php: 7.1
         - php: 7.2
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 services: mongodb
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
         "symfony/yaml": "~2.6|~3.0|~4.0",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^4.8|^5.7|^6.5"
     },
     "suggest": {
         "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",

--- a/composer7.json
+++ b/composer7.json
@@ -47,11 +47,11 @@
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "~1.0.4",
-        "doctrine/mongodb-odm": "~1.0",
+        "doctrine/mongodb-odm": ">=1.0.2",
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
-        "symfony/yaml": "~2.6|~3.0",
-        "phpunit/phpunit": "*"
+        "symfony/yaml": "~2.6|~3.0|~4.0",
+        "phpunit/phpunit": "^4.8|^5.7|^6.5"
     },
     "suggest": {
         "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",

--- a/lib/Gedmo/Tool/Logging/DBAL/QueryAnalyzer.php
+++ b/lib/Gedmo/Tool/Logging/DBAL/QueryAnalyzer.php
@@ -180,15 +180,15 @@ class QueryAnalyzer implements SQLLogger
     /**
      * Create the SQL with mapped parameters
      *
-     * @param string $sql
-     * @param array  $params
-     * @param array  $types
+     * @param string      $sql
+     * @param null|array  $params
+     * @param null|array  $types
      *
      * @return string
      */
     private function generateSql($sql, $params, $types)
     {
-        if (!count($params)) {
+        if (null === $params || !count($params)) {
             return $sql;
         }
         $converted = $this->getConvertedParams($params, $types);

--- a/tests/Gedmo/IpTraceable/IpTraceableTest.php
+++ b/tests/Gedmo/IpTraceable/IpTraceableTest.php
@@ -40,7 +40,7 @@ class IpTraceableTest extends BaseTestCaseORM
     {
         $listener = new IpTraceableListener();
 
-        $this->setExpectedException('Gedmo\Exception\InvalidArgumentException');
+        $this->expectException('Gedmo\Exception\InvalidArgumentException');
 
         $listener->setIpValue('xx.xxx.xx.xxx');
     }

--- a/tests/Gedmo/Mapping/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableMappingTest.php
@@ -14,7 +14,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class LoggableMappingTest extends \PHPUnit_Framework_TestCase
+class LoggableMappingTest extends \PHPUnit\Framework\TestCase
 {
     const YAML_CATEGORY = 'Mapping\Fixture\Yaml\Category';
     private $em;

--- a/tests/Gedmo/Mapping/MappingEventAdapterTest.php
+++ b/tests/Gedmo/Mapping/MappingEventAdapterTest.php
@@ -8,7 +8,7 @@ use Gedmo\Mapping\Event\Adapter\ORM as EventAdapterORM;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Gedmo\Mapping\Mock\Mapping\Event\Adapter\ORM as CustomizedORMAdapter;
 
-class MappingEventAdapterTest extends \PHPUnit_Framework_TestCase
+class MappingEventAdapterTest extends \PHPUnit\Framework\TestCase
 {
     public function testCustomizedAdapter()
     {

--- a/tests/Gedmo/Mapping/MappingTest.php
+++ b/tests/Gedmo/Mapping/MappingTest.php
@@ -11,7 +11,7 @@ use Tree\Fixture\BehavioralCategory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class MappingTest extends \PHPUnit_Framework_TestCase
+class MappingTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_ENTITY_CATEGORY = "Tree\Fixture\BehavioralCategory";
     const TEST_ENTITY_TRANSLATION = "Gedmo\Translatable\Entity\Translation";

--- a/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/CustomDriverTest.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 * @link http://www.gediminasm.org
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
-class CustomDriverTest extends \PHPUnit_Framework_TestCase
+class CustomDriverTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
+++ b/tests/Gedmo/Mapping/MetadataFactory/ForcedMetadataTest.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Version;
 * @link http://www.gediminasm.org
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
-class ForcedMetadataTest extends \PHPUnit_Framework_TestCase
+class ForcedMetadataTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Gedmo/Mapping/SluggableMappingTest.php
+++ b/tests/Gedmo/Mapping/SluggableMappingTest.php
@@ -14,7 +14,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class SluggableMappingTest extends \PHPUnit_Framework_TestCase
+class SluggableMappingTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
     const SLUGGABLE = 'Mapping\Fixture\Sluggable';

--- a/tests/Gedmo/Mapping/TimestampableMappingTest.php
+++ b/tests/Gedmo/Mapping/TimestampableMappingTest.php
@@ -14,7 +14,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TimestampableMappingTest extends \PHPUnit_Framework_TestCase
+class TimestampableMappingTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
     private $em;

--- a/tests/Gedmo/Mapping/TranslatableMappingTest.php
+++ b/tests/Gedmo/Mapping/TranslatableMappingTest.php
@@ -14,7 +14,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TranslatableMappingTest extends \PHPUnit_Framework_TestCase
+class TranslatableMappingTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\User';
     private $em;

--- a/tests/Gedmo/Mapping/TreeMappingTest.php
+++ b/tests/Gedmo/Mapping/TreeMappingTest.php
@@ -13,7 +13,7 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TreeMappingTest extends \PHPUnit_Framework_TestCase
+class TreeMappingTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_YAML_ENTITY_CLASS = 'Mapping\Fixture\Yaml\Category';
     const YAML_CLOSURE_CATEGORY = 'Mapping\Fixture\Yaml\ClosureCategory';

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableDocumentTraitTest.php
@@ -11,7 +11,7 @@ use SoftDeleteable\Fixture\Document\UsingTrait;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class SoftDeletableDocumentTraitTest extends \PHPUnit_Framework_TestCase
+class SoftDeletableDocumentTraitTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var UsingTrait

--- a/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeletableEntityTraitTest.php
@@ -11,7 +11,7 @@ use SoftDeleteable\Fixture\Entity\UsingTrait;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class SoftDeletableEntityTraitTest extends \PHPUnit_Framework_TestCase
+class SoftDeletableEntityTraitTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var UsingTrait

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -42,6 +42,18 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
+    public function expectException($exception)
+    {
+        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
+            return parent::setExpectedException($exception);
+        }
+
+        return parent::expectException($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown()
     {
         if ($this->dm) {

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -22,7 +22,7 @@ use Gedmo\Loggable\LoggableListener;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-abstract class BaseTestCaseMongoODM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DocumentManager

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -57,6 +57,18 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
+    public function expectException($exception)
+    {
+        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
+            return parent::setExpectedException($exception);
+        }
+
+        return parent::expectException($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown()
     {
         foreach ($this->dms as $dm) {

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -33,7 +33,7 @@ use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory as DefaultRepositor
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-abstract class BaseTestCaseOM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EventManager

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -47,6 +47,18 @@ abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception)
+    {
+        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
+            return parent::setExpectedException($exception);
+        }
+
+        return parent::expectException($exception);
+    }
+
+    /**
      * EntityManager mock object together with
      * annotation mapping driver and pdo_sqlite
      * database in memory

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -27,7 +27,7 @@ use Doctrine\ORM\Repository\DefaultRepositoryFactory;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var EntityManager

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -110,7 +110,7 @@ class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
      */
     public function useOfSeparatorInPathSourceShouldThrowAnException()
     {
-        $this->setExpectedException('Gedmo\Exception\RuntimeException');
+        $this->expectException('Gedmo\Exception\RuntimeException');
 
         $category = $this->createCategory();
         $category->setTitle('1'.$this->config['path_separator']);

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTreeLockingTest.php
@@ -43,7 +43,7 @@ class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoODM
     {
         // By default, TreeListenerMock disables the release of the locks
         // for testing purposes
-        $this->setExpectedException('Gedmo\Exception\TreeLockingException');
+        $this->expectException('Gedmo\Exception\TreeLockingException');
 
         $article = $this->createArticle();
         $article->setTitle('1');
@@ -94,7 +94,7 @@ class MaterializedPathODMMongoDBTreeLockingTest extends BaseTestCaseMongoODM
         $this->dm->flush();
 
         // But this should throw it, because the root of its tree ($article) is still locked
-        $this->setExpectedException('Gedmo\Exception\TreeLockingException');
+        $this->expectException('Gedmo\Exception\TreeLockingException');
 
         $repo = $this->dm->getRepository(self::ARTICLE);
         $article2 = $repo->findOneByTitle('2');

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -121,7 +121,7 @@ class MaterializedPathORMTest extends BaseTestCaseORM
      */
     public function useOfSeparatorInPathSourceShouldThrowAnException()
     {
-        $this->setExpectedException('Gedmo\Exception\RuntimeException');
+        $this->expectException('Gedmo\Exception\RuntimeException');
 
         $category = $this->createCategory();
         $category->setTitle('1'.$this->config['path_separator']);

--- a/tests/Gedmo/Uploadable/FileInfo/FileInfoArrayTest.php
+++ b/tests/Gedmo/Uploadable/FileInfo/FileInfoArrayTest.php
@@ -11,7 +11,7 @@ namespace Gedmo\Uploadable\FileInfo;
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-class FileInfoArrayTest extends \PHPUnit_Framework_TestCase
+class FileInfoArrayTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @expectedException RuntimeException

--- a/tests/Gedmo/Uploadable/FilenameGenerator/FilenameGeneratorAlphanumericTest.php
+++ b/tests/Gedmo/Uploadable/FilenameGenerator/FilenameGeneratorAlphanumericTest.php
@@ -12,7 +12,7 @@ use Gedmo\Uploadable\FilenameGenerator\FilenameGeneratorAlphanumeric;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class FilenameGeneratorAlphanumericTest extends \PHPUnit_Framework_TestCase
+class FilenameGeneratorAlphanumericTest extends \PHPUnit\Framework\TestCase
 {
     public function testGenerator()
     {

--- a/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
+++ b/tests/Gedmo/Uploadable/Mapping/ValidatorTest.php
@@ -11,7 +11,7 @@ namespace Gedmo\Uploadable\Mapping;
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
     protected $meta;
 

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -313,7 +313,7 @@ class UploadableEntityTest extends BaseTestCaseORM
      */
     public function testUploadExceptions($error, $exceptionClass)
     {
-        $this->setExpectedException($exceptionClass);
+        $this->expectException($exceptionClass);
 
         $file = new File();
         $fileInfo = $this->generateUploadedFile();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,16 +20,6 @@ define('TESTS_PATH', __DIR__);
 define('TESTS_TEMP_DIR', __DIR__.'/temp');
 define('VENDOR_PATH', realpath(__DIR__.'/../vendor'));
 
-if (!class_exists('PHPUnit_Framework_TestCase') ||
-    version_compare(PHPUnit_Runner_Version::id(), '3.5') < 0
-) {
-    die('PHPUnit framework is required, at least 3.5 version');
-}
-
-if (!class_exists('PHPUnit_Framework_MockObject_MockBuilder')) {
-    die('PHPUnit MockObject plugin is required, at least 1.0.8 version');
-}
-
 /** @var $loader ClassLoader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
Currently manual checks are creating false positive:
https://travis-ci.org/Atlantic18/DoctrineExtensions/jobs/269621530#L306

Because `die()` exists with zero status code, which is considerer a passing build.

We could use `exit(1)`, but I consider harmful to manualy check environment: is is much safer to let the CI fail, otherwise false positive is much easier to occur, like this one.