### PR TITLE
Fix #1173: allow personal translations for entities with composite foreign keys (ORM only, not ODM)

### DIFF
--- a/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
@@ -4,6 +4,7 @@ namespace Gedmo\Translatable\Mapping\Driver;
 
 use Gedmo\Mapping\Driver\AbstractAnnotationDriver;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation;
 
 /**
  * This is an annotation mapping driver for Translatable
@@ -105,8 +106,10 @@ class Annotation extends AbstractAnnotationDriver
             }
         }
 
+        $translationEntityClass = $annot ? new \ReflectionClass($annot->class) : null;
+
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if (is_array($meta->identifier) && count($meta->identifier) > 1 && (!$translationEntityClass || !$translationEntityClass->isSubclassOf(AbstractPersonalTranslation::class))) {
                 throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
             }
         }

--- a/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
@@ -109,7 +109,9 @@ class Annotation extends AbstractAnnotationDriver
         $translationEntityClass = $annot ? new \ReflectionClass($annot->class) : null;
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1 && (!$translationEntityClass || !$translationEntityClass->isSubclassOf(AbstractPersonalTranslation::class))) {
+            if (is_array($meta->identifier)
+                && count($meta->identifier) > 1
+                && (!$translationEntityClass || !$translationEntityClass->isSubclassOf('Gedmo\Translatable\Entity\MappedSuperclass\AbstractPersonalTranslation'))) {
                 throw new InvalidMappingException("Translatable does not support composite identifiers in class - {$meta->name}");
             }
         }

--- a/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/Adapter/ORM.php
@@ -193,8 +193,7 @@ final class ORM extends BaseAdapterORM implements TranslatableAdapter
             ->delete($transClass, 'trans')
         ;
         if ($this->usesPersonalTranslation($transClass)) {
-            $qb->where('trans.object = :object');
-            $qb->setParameter('object', $wrapped->getObject());
+            $this->addObjectJoin($qb, $transClass, $objectClass, $wrapped);
         } else {
             $qb->where(
                 'trans.foreignKey = :objectId',


### PR DESCRIPTION
Basic support for personal translations for entities with composite foreign keys. Tell me if I missed something.