### PR TITLE
[Sluggable] Fix searching for similar slugs when an identifier is custom doctrine type

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php
@@ -64,7 +64,7 @@ class ORM extends BaseAdapterORM implements SluggableAdapter
             if (!$meta->isIdentifier($config['slug'])) {
                 $namedId = str_replace('.', '_', $id);
                 $qb->andWhere($qb->expr()->neq('rec.'.$id, ':'.$namedId));
-                $qb->setParameter($namedId, $value);
+                $qb->setParameter($namedId, $value, $meta->getTypeOfField($namedId));                
             }
         }
         $q = $qb->getQuery();


### PR DESCRIPTION
 Using ```@Gedmo\Slug(...,unique=true)``` on entity's attribute, which has identifier defined with custom type (in this example: Ramsey's UuidType) , causes query like this: 

```
[2017-11-19 13:43:44] doctrine.DEBUG: SELECT c0_.code AS CODE_0 FROM categories c0_ WHERE c0_.code LIKE ? AND c0_.id <> ? ["articletest%","[object] (Ramsey\\Uuid\\Uuid: \"74675c3d-8fec-4cd5-81ba-c3185309ebaa\")"] []
``` 
to be executed, before inserting row into database, unfortunately "setParameter" on query builder doesn't provide type information.

In result, when using doctrine driver oci8, following error is thrown: (what's strange: when using mysql connection, there are no errors)

```
  [Doctrine\DBAL\DBALException]                                                                                                                                        
  An exception occurred while executing 'SELECT c0_.code AS CODE_0 FROM categories c0_ WHERE c0_.code LIKE ? AND c0_.id <> ?' with params ["articletest%", "86333640-  
  1933-4cbb-9b8e-f51862b38e4f"]:                                                                                                                                       
                                                                                                                                                                       
  Warning: oci_bind_by_name(): Invalid variable used for bind 
```
