### PR TITLE
Add an option to enable/disable hard delete

### DIFF
--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -11,6 +11,7 @@ Features:
 - Can be nested with other behaviors
 - Annotation, Yaml and Xml mapping support for extensions
 - Support for 'timeAware' option: When creating an entity set a date of deletion in the future and never worry about cleaning up at expiration time.
+- Support for 'hardDelete' option: When deleting a second time it allows to disable hard delete.
 
 Content:
 
@@ -80,6 +81,8 @@ Available configuration options:
 - **fieldName** - The name of the field that will be used to determine if the object is removed or not (NULL means
 it's not removed. A date value means it was removed). NOTE: The field MUST be nullable.
 
+- **hardDelete** - A boolean to enable or disable hard delete after soft delete has already been done. NOTE: Set to true by default.
+
 **Note:** that SoftDeleteable interface is not necessary, except in cases where
 you need to identify entity as being SoftDeleteable. The metadata is loaded only once then
 cache is activated.
@@ -93,7 +96,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false)
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false, hardDelete=true)
  */
 class Article
 {
@@ -156,6 +159,7 @@ Entity\Article:
     soft_deleteable:
       field_name: deletedAt
       time_aware: false
+      hard_delete: true
   id:
     id:
       type: integer
@@ -187,7 +191,7 @@ Entity\Article:
 
         <field name="deletedAt" type="datetime" nullable="true" />
 
-        <gedmo:soft-deleteable field-name="deletedAt" time-aware="false" />
+        <gedmo:soft-deleteable field-name="deletedAt" time-aware="false" hard-delete="true" />
     </entity>
 
 </doctrine-mapping>
@@ -254,7 +258,7 @@ use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
 
 /**
  * @ORM\Entity
- * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false)
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false, hardDelete=true)
  */
 class UsingTrait
 {

--- a/lib/Gedmo/Mapping/Annotation/SoftDeleteable.php
+++ b/lib/Gedmo/Mapping/Annotation/SoftDeleteable.php
@@ -20,4 +20,7 @@ final class SoftDeleteable extends Annotation
 
     /** @var bool */
     public $timeAware = false;
+
+    /** @var bool */
+    public $hardDelete = true;
 }

--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -44,6 +44,14 @@ class Annotation extends AbstractAnnotationDriver
                 }
                 $config['timeAware'] = $annot->timeAware;
             }
+
+            $config['hardDelete'] = false;
+            if (isset($annot->hardDelete)) {
+                if (!is_bool($annot->hardDelete)) {
+                    throw new InvalidMappingException("hardDelete must be boolean. ".gettype($annot->hardDelete)." provided.");
+                }
+                $config['hardDelete'] = $annot->hardDelete;
+            }
         }
 
         $this->validateFullMetadata($meta, $config);

--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Xml.php
@@ -48,6 +48,11 @@ class Xml extends BaseXml
                 if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'time-aware')) {
                     $config['timeAware'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'time-aware');
                 }
+
+                $config['hardDelete'] = false;
+                if ($this->_isAttributeSet($xml->{'soft-deleteable'}, 'hard-delete')) {
+                    $config['hardDelete'] = $this->_getBooleanAttribute($xml->{'soft-deleteable'}, 'hard-delete');
+                }
             }
         }
     }

--- a/lib/Gedmo/SoftDeleteable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/SoftDeleteable/Mapping/Driver/Yaml.php
@@ -54,6 +54,14 @@ class Yaml extends File implements Driver
                     }
                     $config['timeAware'] = $classMapping['soft_deleteable']['time_aware'];
                 }
+
+                $config['hardDelete'] = false;
+                if (isset($classMapping['soft_deleteable']['hard_delete'])) {
+                    if (!is_bool($classMapping['soft_deleteable']['hard_delete'])) {
+                        throw new InvalidMappingException("hardDelete must be boolean. ".gettype($classMapping['soft_deleteable']['hard_delete'])." provided.");
+                    }
+                    $config['hardDelete'] = $classMapping['soft_deleteable']['hard_delete'];
+                }
             }
         }
     }

--- a/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
+++ b/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
@@ -63,7 +63,8 @@ class SoftDeleteableListener extends MappedEventSubscriber
             if (isset($config['softDeleteable']) && $config['softDeleteable']) {
                 $reflProp = $meta->getReflectionProperty($config['fieldName']);
                 $oldValue = $reflProp->getValue($object);
-                if ($oldValue instanceof \Datetime) {
+
+                if (isset($config['hardDelete']) && $config['hardDelete'] && $oldValue instanceof \Datetime) {
                     continue; // want to hard delete
                 }
 

--- a/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
+++ b/tests/Gedmo/SoftDeleteable/Fixture/Entity/UserNoHardDelete.php
@@ -1,0 +1,54 @@
+<?php
+namespace SoftDeleteable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt", hardDelete=false)
+ */
+class UserNoHardDelete
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string")
+     */
+    private $username;
+
+    /**
+     * @ORM\Column(name="deleted_time", type="datetime", nullable=true)
+     */
+    private $deletedAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function setDeletedAt($deletedAt)
+    {
+        $this->deletedAt = $deletedAt;
+    }
+
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+}


### PR DESCRIPTION
Soft delete works like this:
- first call: it sets the fieldname with a new DateTime
- second call: it hard deletes your record

## Problem
I'd like to be able to disable the hard delete but there's no configuration to do it.

## Solution
I suggest to add a parameter in order to disable the hard delete.
By default I let the hardDelete parameter to true in order to keep the default behaviour.

Hope you'll like it.