### PR TITLE
Fixed #1867 - fixed broken array syntax for php 5.3 - removed [] syntax

### DIFF
--- a/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Sluggable/Mapping/Driver/Annotation.php
@@ -148,7 +148,7 @@ class Annotation extends AbstractAnnotationDriver
             if ($slug->unique_base && !$meta->hasField($slug->unique_base) && !$meta->hasAssociation($slug->unique_base)) {
                 throw new InvalidMappingException("Unable to find [{$slug->unique_base}] as mapped property in entity - {$meta->name}");
             }
-            $sluggableFields = [];
+            $sluggableFields = array();
             foreach ($slug->fields as $field) {
                 $sluggableFields[] = $fieldNamePrefix ? ($fieldNamePrefix . '.' . $field) : $field;
             }

--- a/tests/Gedmo/Sortable/Fixture/NotifyNode.php
+++ b/tests/Gedmo/Sortable/Fixture/NotifyNode.php
@@ -18,7 +18,7 @@ class NotifyNode extends AbstractNode implements NotifyPropertyChanged
      * 
      * @var PropertyChangedListener[]
      */
-    private $_propertyChangedListeners = [];
+    private $_propertyChangedListeners = array();
     
     /**
      * Adds a listener that wants to be notified about property changes.

--- a/tests/Gedmo/Sortable/SortableTest.php
+++ b/tests/Gedmo/Sortable/SortableTest.php
@@ -799,7 +799,7 @@ class SortableTest extends BaseTestCaseORM
     public function shouldFixIssue1809()
     {
         $manager = $this->em;
-        $nodes = [];
+        $nodes = array();
         for ($i = 1; $i <= 3; $i++) {
             $node = new NotifyNode();
             $node->setName("Node".$i);


### PR DESCRIPTION
based on requirement on packagist, version v2.4.* should support php: >=5.3.2. fixed array syntax to support 5.3.29