### PR TITLE
[Translatable] Fix replacement of last group by element

### DIFF
--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -428,7 +428,7 @@ class TranslationWalker extends SqlWalker
     private function replace(array $repl, $str)
     {
         foreach ($repl as $target => $result) {
-            $str = preg_replace_callback('/(\s|\()('.$target.')(,?)(\s|\))/smi', function ($m) use ($result) {
+            $str = preg_replace_callback('/(\s|\()('.$target.')(,?)(\s|\)|$)/smi', function ($m) use ($result) {
                 return $m[1].$result.$m[3].$m[4];
             }, $str);
         }


### PR DESCRIPTION
Some Sql vendors (like Sql Server) require every selected element to be in
the group by clause. Because the translation walker adds additional
columns, those columns must be added to the group by as well. The regex was incorrect and did not replace the very
last element in the group by clause.