### PR TITLE
Change wording to be a bit more explicit with @Versioned

### DIFF
--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -68,7 +68,7 @@ class Annotation extends AbstractAnnotationDriver
             // versioned property
             if ($this->reader->getPropertyAnnotation($property, self::VERSIONED)) {
                 if (!$this->isMappingValid($meta, $field)) {
-                    throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                    throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                 }
                 if (isset($meta->embeddedClasses[$field])) {
                     $this->inspectEmbeddedForVersioned($field, $config, $meta);

--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -49,7 +49,7 @@ class Yaml extends File implements Driver
                 if (isset($fieldMapping['gedmo'])) {
                     if (in_array('versioned', $fieldMapping['gedmo'])) {
                         if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                         }
                         // fields cannot be overrided and throws mapping exception
                         $config['versioned'][] = $field;
@@ -63,7 +63,7 @@ class Yaml extends File implements Driver
                 if (isset($fieldMapping['gedmo'])) {
                     if (in_array('versioned', $fieldMapping['gedmo'])) {
                         if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                         }
                         // fields cannot be overrided and throws mapping exception
                         $config['versioned'][] = $field;
@@ -77,7 +77,7 @@ class Yaml extends File implements Driver
                 if (isset($fieldMapping['gedmo'])) {
                     if (in_array('versioned', $fieldMapping['gedmo'])) {
                         if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                         }
                         // fields cannot be overrided and throws mapping exception
                         $config['versioned'][] = $field;
@@ -91,7 +91,7 @@ class Yaml extends File implements Driver
                 if (isset($fieldMapping['gedmo'])) {
                     if (in_array('versioned', $fieldMapping['gedmo'])) {
                         if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                         }
                         // fields cannot be overrided and throws mapping exception
                         $config['versioned'][] = $field;
@@ -105,7 +105,7 @@ class Yaml extends File implements Driver
                 if (isset($fieldMapping['gedmo'])) {
                     if (in_array('versioned', $fieldMapping['gedmo'])) {
                         if ($meta->isCollectionValuedAssociation($field)) {
-                            throw new InvalidMappingException("Cannot versioned [{$field}] as it is collection in object - {$meta->name}");
+                            throw new InvalidMappingException("Cannot apply versioning to field [{$field}] as it is collection in object - {$meta->name}");
                         }
                         // fields cannot be overrided and throws mapping exception
                         $mapping = $this->_getMapping($fieldMapping['class']);


### PR DESCRIPTION
This change simply improves the error message in the event that a `Versioned` behaviour cannot be applied so it's understood a little easier.