### PR TITLE
Add row_format=dynamic to ext_log_entries and ext_translations 

### DIFF
--- a/lib/Gedmo/Loggable/Entity/LogEntry.php
+++ b/lib/Gedmo/Loggable/Entity/LogEntry.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table(
  *     name="ext_log_entries",
+ *     options={"row_format":"DYNAMIC"},
  *  indexes={
  *      @ORM\Index(name="log_class_lookup_idx", columns={"object_class"}),
  *      @ORM\Index(name="log_date_lookup_idx", columns={"logged_at"}),

--- a/lib/Gedmo/Translatable/Entity/Translation.php
+++ b/lib/Gedmo/Translatable/Entity/Translation.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Entity;
  *
  * @Table(
  *         name="ext_translations",
+ *         options={"row_format":"DYNAMIC"},
  *         indexes={@Index(name="translations_lookup_idx", columns={
  *             "locale", "object_class", "foreign_key"
  *         })},


### PR DESCRIPTION
...to avoid Index column size too large on MySQL < 5.7 (must be combined with innodb_large_prefix=on option in the MySQL server config) - fixes #1904