### PR TITLE
Revert "[SoftDeleteable] Detach soft-deleted objects from entity manager after flush"

### DIFF
--- a/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
+++ b/lib/Gedmo/SoftDeleteable/SoftDeleteableListener.php
@@ -30,13 +30,6 @@ class SoftDeleteableListener extends MappedEventSubscriber
     const POST_SOFT_DELETE = "postSoftDelete";
 
     /**
-     * Objects soft-deleted on flush.
-     *
-     * @var array
-     */
-    private $softDeletedObjects = array();
-
-    /**
      * {@inheritdoc}
      */
     public function getSubscribedEvents()
@@ -44,7 +37,6 @@ class SoftDeleteableListener extends MappedEventSubscriber
         return array(
             'loadClassMetadata',
             'onFlush',
-            'postFlush'
         );
     }
 
@@ -100,29 +92,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
                     self::POST_SOFT_DELETE,
                     $ea->createLifecycleEventArgsInstance($object, $om)
                 );
-
-                $this->softDeletedObjects[] = $object;
             }
-        }
-    }
-
-    /**
-     * Detach soft-deleted objects from object manager.
-     *
-     * @param \Doctrine\Common\EventArgs $args
-     *
-     * @return void
-     *
-     * @throws \Gedmo\Exception\InvalidArgumentException
-     */
-    public function postFlush(EventArgs $args)
-    {
-        $ea = $this->getEventAdapter($args);
-        $om = $ea->getObjectManager();
-
-        foreach ($this->softDeletedObjects as $index => $object) {
-            $om->detach($object);
-            unset($this->softDeletedObjects[$index]);
         }
     }
 

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -79,28 +79,6 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
     /**
      * @test
      */
-    public function shouldNotFetchSoftDeletedItemByIdIfDetachOnDeleteEnabled()
-    {
-        $repo = $this->em->getRepository(self::USER_CLASS);
-
-        $newUser = new User();
-        $newUser->setUsername('test_user');
-
-        $this->em->persist($newUser);
-        $this->em->flush();
-
-        $userId = $newUser->getId();
-
-        $this->em->remove($newUser);
-        $this->em->flush();
-
-        $user = $repo->find($userId);
-        $this->assertNull($user);
-    }
-
-    /**
-     * @test
-     */
     public function shouldSoftlyDeleteIfColumnNameDifferFromPropertyName()
     {
         $repo = $this->em->getRepository(self::USER_CLASS);
@@ -598,7 +576,7 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
             self::OTHER_ARTICLE_CLASS,
             self::OTHER_COMMENT_CLASS,
             self::MAPPED_SUPERCLASS_CHILD_CLASS,
-            self::USER_NO_HARD_DELETE_CLASS
+            self::USER_NO_HARD_DELETE_CLASS,
         );
     }
 }


### PR DESCRIPTION
Reverts Atlantic18/DoctrineExtensions#1868

causes internal failures to proxies and other unexpected behavior, closes #1912 