### PR TITLE
Trigger 'on change' for new entities

### DIFF
--- a/lib/Gedmo/AbstractTrackingListener.php
+++ b/lib/Gedmo/AbstractTrackingListener.php
@@ -92,7 +92,7 @@ abstract class AbstractTrackingListener extends MappedEventSubscriber
                 }
             }
 
-            if (!$uow->isScheduledForInsert($object) && isset($config['change'])) {
+            if (isset($config['change'])) {
                 foreach ($config['change'] as $options) {
                     if (isset($changeSet[$options['field']])) {
                         continue; // value was set manually

--- a/lib/Gedmo/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Mapping/Event/Adapter/ORM.php
@@ -107,7 +107,16 @@ class ORM implements AdapterInterface
      */
     public function getObjectChangeSet($uow, $object)
     {
-        return $uow->getEntityChangeSet($object);
+        $realObjectChangeSet = array();
+
+        $objectChangeSet = $uow->getEntityChangeSet($object);
+        foreach ($objectChangeSet as $propertyName => $propertyChangeSet) {
+            if ($propertyChangeSet[0] !== $propertyChangeSet[1]) {
+                $realObjectChangeSet[$propertyName] = $propertyChangeSet;
+            }
+        }
+
+        return $realObjectChangeSet;
     }
 
     /**

--- a/tests/Gedmo/Timestampable/TimestampableTest.php
+++ b/tests/Gedmo/Timestampable/TimestampableTest.php
@@ -107,9 +107,9 @@ class TimestampableTest extends BaseTestCaseORM
         $sport = $this->em->getRepository(self::ARTICLE)->findOneByTitle('Sport');
         $this->assertNotNull($sc = $sport->getCreated());
         $this->assertNotNull($su = $sport->getUpdated());
-        $this->assertNull($sport->getContentChanged());
+        $this->assertNotNull($scc = $sport->getContentChanged());
         $this->assertNull($sport->getPublished());
-        $this->assertNull($sport->getAuthorChanged());
+        $this->assertNotNull($sport->getAuthorChanged());
 
         $author = $sport->getAuthor();
         $author->setName('New author');
@@ -130,7 +130,7 @@ class TimestampableTest extends BaseTestCaseORM
         $this->em->flush();
 
         $sportComment = $this->em->getRepository(self::COMMENT)->findOneByMessage('hello');
-        $this->assertNotNull($scc = $sportComment->getClosed());
+        $this->assertNotNull($sportComment->getClosed());
         $this->assertNotNull($sp = $sport->getPublished());
         $this->assertNotNull($sa = $sport->getAuthorChanged());
 


### PR DESCRIPTION
This PR adds changes to activate/fix the 'on change' behavior of `Timestampable` for new entities.

Related issue: #1653 