### PR TITLE
Fix calculating the change set data for embedded collections

### DIFF
--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -247,7 +247,6 @@ class LoggableListener extends MappedEventSubscriber
             if (method_exists($meta, 'isCollectionValuedEmbed') && $meta->isCollectionValuedEmbed($field) && $value) {
                 $embedValues = array();
                 foreach ($value as $embedValue) {
-                    $wrapped = AbstractWrapper::wrap($embedValue, $om);
                     $embedValues[] = $this->getObjectChangeSetData($ea, $embedValue, $logEntry);
                 }
                 $value = $embedValues;


### PR DESCRIPTION
Setting the `$wrapped` variable within the loop is not necessary to calculate the change set and setting it will make the code not work properly for the next properties