### PR TITLE
Protected methods to be able to extend the listener

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -155,7 +155,7 @@ class SortableListener extends MappedEventSubscriber
      * @param ClassMetadata   $meta
      * @param object          $object
      */
-    private function processInsert(SortableAdapter $ea, array $config, $meta, $object)
+    protected function processInsert(SortableAdapter $ea, array $config, $meta, $object)
     {
         $em = $ea->getObjectManager();
         $uow = $em->getUnitOfWork();
@@ -223,7 +223,7 @@ class SortableListener extends MappedEventSubscriber
      * @param ClassMetadata   $meta
      * @param object          $object
      */
-    private function processUpdate(SortableAdapter $ea, array $config, $meta, $object)
+    protected function processUpdate(SortableAdapter $ea, array $config, $meta, $object)
     {
         $em = $ea->getObjectManager();
         $uow = $em->getUnitOfWork();
@@ -363,7 +363,7 @@ class SortableListener extends MappedEventSubscriber
      * @param ClassMetadata   $meta
      * @param object          $object
      */
-    private function processDeletion(SortableAdapter $ea, array $config, $meta, $object)
+    protected function processDeletion(SortableAdapter $ea, array $config, $meta, $object)
     {
         $position = $meta->getReflectionProperty($config['position'])->getValue($object);
 
@@ -386,7 +386,7 @@ class SortableListener extends MappedEventSubscriber
      * Persists relocations to database.
      * @param SortableAdapter $ea
      */
-    private function persistRelocations(SortableAdapter $ea)
+    protected function persistRelocations(SortableAdapter $ea)
     {
         if (!$this->persistenceNeeded) {
             return;
@@ -504,7 +504,7 @@ class SortableListener extends MappedEventSubscriber
         }
     }
 
-    private function getHash($groups, array $config)
+    protected function getHash($groups, array $config)
     {
         $data = $config['useObjectClass'];
         foreach ($groups as $group => $val) {
@@ -519,7 +519,7 @@ class SortableListener extends MappedEventSubscriber
         return md5($data);
     }
 
-    private function getMaxPosition(SortableAdapter $ea, $meta, $config, $object, array $groups = array())
+    protected function getMaxPosition(SortableAdapter $ea, $meta, $config, $object, array $groups = array())
     {
         $em = $ea->getObjectManager();
         $uow = $em->getUnitOfWork();
@@ -566,7 +566,7 @@ class SortableListener extends MappedEventSubscriber
      * @param int    $delta   The delta to add to relocated nodes
      * @param array  $exclude Objects to be excluded from relocation
      */
-    private function addRelocation($hash, $class, $groups, $start, $stop, $delta, array $exclude = array())
+    protected function addRelocation($hash, $class, $groups, $start, $stop, $delta, array $exclude = array())
     {
         if (!array_key_exists($hash, $this->relocations)) {
             $this->relocations[$hash] = array('name' => $class, 'groups' => $groups, 'deltas' => array());
@@ -594,7 +594,7 @@ class SortableListener extends MappedEventSubscriber
      *
      * @return array
      */
-    private function getGroups($meta, $config, $object)
+    protected function getGroups($meta, $config, $object)
     {
         $groups = array();
         if (isset($config['groups'])) {


### PR DESCRIPTION
Hi, this PR will allow us to extend the listener and modify some behaviours in specific scenarios. 

For example, I have a very large table (80k rows) and only some of them are grouped, the others have their group = null (aprox 50k rows). Every time i take one row and add it to a group, the listener will try to update the "null" group with the 50k rows, which takes a LOT of time. So, I need to override the addRelocation method to not add the relocation in case the group is null.