### PR TITLE
[Sortable] Fix issue with position synchronization when items are add…

### DIFF
--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -579,6 +579,10 @@ class SortableListener extends MappedEventSubscriber
                     $val['delta'] += $needle['delta'];
                     $val['exclude'] = array_merge($val['exclude'], $needle['exclude']);
                     throw new \Exception("Found delta. No need to add it again.");
+                // For every deletion relocation add newly created object to the list of excludes
+                // otherwise position update queries will run for created objects as well.
+                } elseif (-1 == $val['delta'] && 1 == $needle['delta']) {
+                    $val['exclude'] = array_merge($val['exclude'], $needle['exclude']);
                 }
             }, $newDelta);
             $this->relocations[$hash]['deltas'][] = $newDelta;


### PR DESCRIPTION
…ed and deleted in one operation

Deletion relocations must be aware of newly created objects in order to generate correct position update queries.

However I kind of don't understand original intention of collecting newly created objects in "excludes" for add relocation. There is most probably something missing and I was not able to unravel it correctly. I would really appreciate if anyone fix this piece the way author has intended to.