### PR TITLE
Use CURRENT_TIMESTAMP instead of date to allow caching queries in Softdeletable

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -60,8 +60,7 @@ class SoftDeleteableFilter extends SQLFilter
 
         $addCondSql = $platform->getIsNullExpression($targetTableAlias.'.'.$column);
         if (isset($config['timeAware']) && $config['timeAware']) {
-            $now = $conn->quote(date($platform->getDateTimeFormatString())); // should use UTC in database and PHP
-            $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$now})";
+            $addCondSql = "({$addCondSql} OR {$targetTableAlias}.{$column} > {$platform->getCurrentTimestampSQL()})";
         }
 
         return $addCondSql;

--- a/lib/Gedmo/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Gedmo/SoftDeleteable/Query/TreeWalker/Exec/MultiTableDeleteExecutor.php
@@ -36,7 +36,11 @@ class MultiTableDeleteExecutor extends BaseMultiTableDeleteExecutor
 
             if (isset($matches[1]) && $meta->getQuotedTableName($platform) === $matches[1]) {
                 $sqlStatements[$index] = str_replace('DELETE FROM', 'UPDATE', $stmt);
-                $sqlStatements[$index] = str_replace('WHERE', 'SET '.$config['fieldName'].' = "'.date('Y-m-d H:i:s').'" WHERE', $sqlStatements[$index]);
+                $sqlStatements[$index] = str_replace(
+                    'WHERE',
+                    'SET '.$config['fieldName'].' = '.$platform->getCurrentTimestampSQL().' WHERE',
+                    $sqlStatements[$index]
+                );
             } else {
                 // We have to avoid the removal of registers of child entities of a SoftDeleteable entity
                 unset($sqlStatements[$index]);

--- a/lib/Gedmo/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
+++ b/lib/Gedmo/SoftDeleteable/Query/TreeWalker/SoftDeleteableWalker.php
@@ -75,9 +75,7 @@ class SoftDeleteableWalker extends SqlWalker
         $quotedTableName = $class->getQuotedTableName($this->platform);
         $quotedColumnName = $class->getQuotedColumnName($this->deletedAtField, $this->platform);
 
-        $sql = 'UPDATE '.$quotedTableName.' SET '.$quotedColumnName.' = '.$this->conn->quote(date(
-            $this->platform->getDateTimeFormatString()
-        ));
+        $sql = 'UPDATE '.$quotedTableName.' SET '.$quotedColumnName.' = '.$this->platform->getCurrentTimestampSQL();
 
         return $sql;
     }


### PR DESCRIPTION
Using CURRENT_TIMESTAMP instead of current datetime value allows queries to be cached.
`$platform->getCurrentTimestampSQL()` provides platform-specific SQL implementation.
This feature is available in doctrine/dbal v2.2, so this PR is backwards-compatible.

```
# Cachable
SELECT *
FROM foo f
WHERE f.deleted_at > CURRENT_TIMESTAMP

# Non-cachable
SELECT *
FROM foo f
WHERE f.deleted_at > ?
["2018-08-19 10:11:12"]
```