### PR TITLE
[RFC] Require and configure PHP CS Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/temp/*.log
 /composer.lock
 /composer.phar
 .idea
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/lib')
+    ->in(__DIR__.'/example');
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        'array_syntax' => array('syntax' => 'long'),
+        'ordered_imports' => array('sort_algorithm' => 'alpha'),
+    ))
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "doctrine/mongodb-odm": ">=1.0.2",
         "doctrine/orm": ">=2.5.0",
         "doctrine/common": ">=2.5.0",
+        "friendsofphp/php-cs-fixer": "^2.12",
         "symfony/yaml": "~2.6|~3.0|~4.0",
         "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
     },
@@ -61,6 +62,9 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "scripts": {
+        "fix-cs": "php bin/php-cs-fixer fix --config=.php_cs.dist"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
[PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) is a tool for automatically adjusting code styles based on a set of configured rules. I started with a basic configuration:

* `@Symfony` ruleset, which includes PSR-1 & 2 and other rules they prefer. I consider their standards a good starting point, especially considering Doctrine's heavy ties to the framework.
* Alphabetical ordering of `use` namespace statements.
* Force long array syntax (`array()` vs `[]`). This would be reversed when the minimum PHP version is bumped.

There are others that I would personally include, however this is a community project, so I'm PRing it for comments.

A Composer script is there to make running the fixer easier: `composer fix-cs`