### PR TITLE
[BUG] Doctrine Metadata Cache lifetime should not be passed as null

### DIFF
--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Mapping;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
@@ -101,8 +102,10 @@ class ExtensionMetadataFactory
         // cache the metadata (even if it's empty)
         // caching empty metadata will prevent re-parsing non-existent annotations
         $cacheId = self::getCacheId($meta->name, $this->extensionNamespace);
+
         if ($cacheDriver = $cmf->getCacheDriver()) {
-            $cacheDriver->save($cacheId, $config, null);
+            /**@var $cacheDriver Cache*/
+            $cacheDriver->save($cacheId, $config);
         }
 
         return $config;

--- a/lib/Gedmo/Tree/Strategy/ORM/Closure.php
+++ b/lib/Gedmo/Tree/Strategy/ORM/Closure.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tree\Strategy\ORM;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Version;
@@ -154,7 +155,8 @@ class Closure implements Strategy
             'columns' => array('depth'),
         );
         if ($cacheDriver = $cmf->getCacheDriver()) {
-            $cacheDriver->save($closureMetadata->name."\$CLASSMETADATA", $closureMetadata, null);
+            /**@var $cacheDriver Cache*/
+            $cacheDriver->save($closureMetadata->name."\$CLASSMETADATA", $closureMetadata);
         }
     }
 


### PR DESCRIPTION
Signature of \Doctrine\Common\Cache\Cache::save does not accept null (https://github.com/doctrine/cache/blob/6f9810e194acace22e360a1398cf228132e5b4b2/lib/Doctrine/Common/Cache/Cache.php#L55) and pass lifetime as null null works not properly on different cache implementations.
For instance, on \Doctrine\Common\Cache\PhpFileCache.