### PR TITLE
[WIP] Upgrade to PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=7.1.0",
         "behat/transliterator": "~1.2",
         "doctrine/common": "~2.4"
     },


### PR DESCRIPTION
I was surprised to see we still support PHP 5.3, which is EOL for ages.

Let's support a [supported version](http://php.net/supported-versions.php) of PHP.

Todo: 
- [ ] Remove tests
- [ ] Remove composer7.json