### PR TITLE
[Loggable] Adds missing string cast, causing indexes not to be used due to incorrect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Loggable
+#### Fixed
+- Added missing string casting of `objectId` in `LogEntryRepository::revert()` method
 
 ## [2.4.37] - 2019-03-17
 ### Translatable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ a release.
 ## [Unreleased]
 ### Loggable
 #### Fixed
-- Added missing string casting of `objectId` in `LogEntryRepository::revert()` method
+- Added missing string casting of `objectId` in `LogEntryRepository::revert()` method (#2009)
 
 ## [2.4.37] - 2019-03-17
 ### Translatable

--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -88,7 +88,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.version <= :version";
         $dql .= " ORDER BY log.version ASC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass', 'version'));
         $logs = $q->getResult();


### PR DESCRIPTION
Before:

`EXPLAIN select * from ext_log_entries where object_class = 'My\\Class' and object_id = 2;`

```
id    select_type    table    type    possible_keys    key    key_len    ref    rows    Extra
1    SIMPLE    ext_log_entries    ALL    object_id_and_class    NULL    NULL    NULL    200424    Using where
```


After:
object_id is a varchar:

`EXPLAIN select * from ext_log_entries where object_class = 'My\\Class' and object_id = '2';`

```
id    select_type    table    type    possible_keys    key    key_len    ref    rows    Extra
1    SIMPLE    ext_log_entries    ref    object_id_and_class    object_id_and_class    1025    const,const    836    Using where
```