### PR TITLE
Return `parent` instead of throwing Exception for Translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ a release.
 #### Fixed
 - Added missing string casting of `objectId` in `LogEntryRepository::revert()` method (#2009)
 
+### Translatable
+#### Fixed
+- Return `parent` instead of throwing Exception for Translatable (#2018)
+
 ## [2.4.37] - 2019-03-17
 ### Translatable
 #### Fixed

--- a/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
+++ b/lib/Gedmo/Translatable/Query/TreeWalker/TranslationWalker.php
@@ -104,8 +104,10 @@ class TranslationWalker extends SqlWalker
      */
     public function getExecutor($AST)
     {
+        // If it's not a Select, the TreeWalker ought to skip it, and just return the parent.
+        // @see https://github.com/Atlantic18/DoctrineExtensions/issues/2013
         if (!$AST instanceof SelectStatement) {
-            throw new \Gedmo\Exception\UnexpectedValueException('Translation walker should be used only on select statement');
+            return parent::getExecutor($AST);
         }
         $this->prepareTranslatedComponents();
 


### PR DESCRIPTION
Fixes #2013 