### PR TITLE
[ReferenceIntegrity] Get class from meta in ReferenceIntegrityListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ a release.
 #### Fixed
 - Remove hard-coded parent column name in repository prev/next sibling queries [#2020]
 
+### ReferenceIntegrity
+#### Fixed
+- Get class from meta in ReferenceIntegrityListener [#2021]
+
 ## [2.4.37] - 2019-03-17
 ### Translatable
 #### Fixed

--- a/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
+++ b/lib/Gedmo/ReferenceIntegrity/ReferenceIntegrityListener.php
@@ -54,7 +54,7 @@ class ReferenceIntegrityListener extends MappedEventSubscriber
         $class = get_class($object);
         $meta = $om->getClassMetadata($class);
 
-        if ($config = $this->getConfiguration($om, $class)) {
+        if ($config = $this->getConfiguration($om, $meta->name)) {
             foreach ($config['referenceIntegrity'] as $property => $action) {
                 $reflProp = $meta->getReflectionProperty($property);
                 $refDoc = $reflProp->getValue($object);


### PR DESCRIPTION
Get class from meta to get real document class instead of its proxy. 

Fixes: #1077