### PR TITLE
[Bug fixed] Calling Listener's parent constructor for LoggableListener

### DIFF
--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -57,6 +57,11 @@ class LoggableListener extends MappedEventSubscriber
      */
     protected $pendingRelatedObjects = array();
 
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
     /**
      * Set username for identification
      *


### PR DESCRIPTION
This PR if applied to all Listener's constructors, will fix this bug #2012.