### PR TITLE
[Bug fixed] Calling Listener's parent constructor for ReferencesListener

### DIFF
--- a/lib/Gedmo/References/ReferencesListener.php
+++ b/lib/Gedmo/References/ReferencesListener.php
@@ -21,6 +21,7 @@ class ReferencesListener extends MappedEventSubscriber
 
     public function __construct(array $managers = array())
     {
+        parent::__construct();
         $this->managers = $managers;
     }
 


### PR DESCRIPTION
This PR if applied to all Listener's constructors, will fix this bug #2012.