### PR TITLE
[Translatable]: fix duplicate inherited properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ a release.
 #### Fixed
 - Remove hard-coded parent column name in repository prev/next sibling queries [#2020]
 
+### Translatable
+#### Fixed
+- Fix duplicate inherited properties [#2029]
+
 ## [2.4.37] - 2019-03-17
 ### Translatable
 #### Fixed

--- a/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php
@@ -91,6 +91,9 @@ class Annotation extends AbstractAnnotationDriver
         // Embedded entity
         if (property_exists($meta, 'embeddedClasses') && $meta->embeddedClasses) {
             foreach ($meta->embeddedClasses as $propertyName => $embeddedClassInfo) {
+                if ($meta->isInheritedEmbeddedClass($propertyName)) {
+                    continue;
+                }
                 $embeddedClass = new \ReflectionClass($embeddedClassInfo['class']);
                 foreach ($embeddedClass->getProperties() as $embeddedProperty) {
                     if ($translatable = $this->reader->getPropertyAnnotation($embeddedProperty, self::TRANSLATABLE)) {

--- a/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Translatable/Mapping/Driver/Xml.php
@@ -53,6 +53,9 @@ class Xml extends BaseXml
 
         if (property_exists($meta, 'embeddedClasses') && $meta->embeddedClasses) {
             foreach ($meta->embeddedClasses as $propertyName => $embeddedClassInfo) {
+                if ($meta->isInheritedEmbeddedClass($propertyName)) {
+                    continue;
+                }
                 $xmlEmbeddedClass = $this->_getMapping($embeddedClassInfo['class']);
                 $this->inspectElementsForTranslatableFields($xmlEmbeddedClass, $config, $propertyName);
             }


### PR DESCRIPTION
Q | A
-- | --
Branch? | v2.4.x
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no

There currently is an issue with the gedmo translatable. Use case:

- Abstract class A (Product) with single table inheritance has a property $name, which is a doctrine embeddable and contains a property $value. This value property has the Gedmo\Translatable annotation.

- Class B (Pack) extends class A and has it's own properties.

When querying for class B gedmo will search for all translatable properties and will return the name.value property twice because it's first checking the parent class and later on it's own class. With this fix, when the embedded property is inherited, the property will not be added twice to the config. Otherwise this will give a duplicate join with same table alias.
