### PR TITLE
[2.4.x] No longer test lowest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ sudo: false
 matrix:
     include:
         - php: 5.4
-          env: phpunit_exclude_groups=datetimeinterface dependencies=lowest
+          env: phpunit_exclude_groups=datetimeinterface
         - php: 5.5
         - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: 7.1
-          env: dependencies=lowest
         - php: 7.2
-          env: dependencies=lowest
 
 cache:
     directories:
@@ -27,12 +25,7 @@ before_install:
     - if [[ "$TRAVIS_PHP_VERSION" != 5.* ]]; then cp composer7.json composer.json; fi
 
 install:
-    - |
-        if [[ "$dependencies" = "lowest" ]]; then
-            composer update --prefer-lowest --prefer-stable -n
-        else
-            composer install --prefer-dist
-        fi
+    - composer install --prefer-dist
 
 script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
+dist: trusty
 language: php
 
 sudo: false
 
 matrix:
     include:
-        - php: 5.4
+        - php: '5.4'
           env: phpunit_exclude_groups=datetimeinterface
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
-        - php: 7.1
-        - php: 7.1
-        - php: 7.2
+        - php: '5.5'
+        - php: '5.6'
+        - php: '7.0'
+        - php: '7.1'
+        - php: '7.2'
 
 cache:
     directories:


### PR DESCRIPTION
Travis builds have been failing since Travis updated to MongoDB 4.0. Somewhere in an old release of a “require-dev” dependency, likely Doctrine’s ODM (or one of its dependencies), a deprecated MongoDB feature called `$pushAll` is still being used.

This deprecated feature isn’t used on the latest version of dev dependencies, so somewhere in there it was bug fixed or whatever.

Bumping the minimum version requirements in composer.json would be a breaking change and require a new major release. While some of this is already being worked on for Extensions 3.0, we would like to have normal CI tests for 2.4.x in the meantime. That’s what this hopes to accomplish.