### PR TITLE
Adding support for ODM 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "doctrine/mongodb-odm": ">=1.0.2 <2.0",
         "doctrine/orm": ">=2.5.0",
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-        "symfony/yaml": "~2.6 || ~3.0 || ~4.0"
+        "symfony/yaml": "^2.6 || ^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {
         "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",

--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,11 @@
         "doctrine/common": "~2.4"
     },
     "conflict": {
-        "doctrine/annotations": "<1.2",
-        "doctrine/mongodb-odm": ">=2.0"
+        "doctrine/annotations": "<1.2"
     },
     "require-dev": {
         "doctrine/common": ">=2.5.0",
-        "doctrine/mongodb-odm": ">=1.0.2 <2.0",
+        "doctrine/mongodb-odm": ">=1.0.2 || ^2.0",
         "doctrine/orm": ">=2.5.0",
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
         "symfony/yaml": "^2.6 || ^3.0 || ^4.0 || ^5.0"

--- a/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Document/Repository/LogEntryRepository.php
@@ -5,7 +5,7 @@ namespace Gedmo\Loggable\Document\Repository;
 use Gedmo\Loggable\Document\LogEntry;
 use Gedmo\Tool\Wrapper\MongoDocumentWrapper;
 use Gedmo\Loggable\LoggableListener;
-use Doctrine\ODM\MongoDB\DocumentRepository;
+use Gedmo\MiddleManDocumentRepository;
 use Doctrine\ODM\MongoDB\Cursor;
 
 /**
@@ -15,7 +15,7 @@ use Doctrine\ODM\MongoDB\Cursor;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class LogEntryRepository extends DocumentRepository
+class LogEntryRepository extends MiddleManDocumentRepository
 {
     /**
      * Currently used loggable listener

--- a/lib/Gedmo/MiddleManDocumentRepository.php
+++ b/lib/Gedmo/MiddleManDocumentRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gedmo;
+
+if (class_exists('\Doctrine\ODM\MongoDB\Repository\DocumentRepository')) {
+    class MiddleManDocumentRepository extends \Doctrine\ODM\MongoDB\Repository\DocumentRepository {}
+} else {
+    class MiddleManDocumentRepository extends \Doctrine\ODM\MongoDB\DocumentRepository {}
+}

--- a/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
@@ -2,8 +2,8 @@
 
 namespace Gedmo\Translatable\Document\Repository;
 
+use Gedmo\MiddleManDocumentRepository;
 use Gedmo\Translatable\TranslatableListener;
-use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;
@@ -18,7 +18,7 @@ use Gedmo\Translatable\Mapping\Event\Adapter\ODM as TranslatableAdapterODM;
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-class TranslationRepository extends DocumentRepository
+class TranslationRepository extends MiddleManDocumentRepository
 {
     /**
      * Current TranslatableListener instance used

--- a/lib/Gedmo/Translatable/Mapping/Event/Adapter/ODM.php
+++ b/lib/Gedmo/Translatable/Mapping/Event/Adapter/ODM.php
@@ -4,7 +4,6 @@ namespace Gedmo\Translatable\Mapping\Event\Adapter;
 
 use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\Cursor;
 use Gedmo\Translatable\Mapping\Event\TranslatableAdapter;
 
@@ -50,8 +49,11 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
         if ($this->usesPersonalTranslation($translationClass)) {
             // first try to load it using collection
             foreach ($wrapped->getMetadata()->fieldMappings as $mapping) {
+                $association = true === class_exists('Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo') ?
+                    \Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo::REFERENCE_MANY :
+                    \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::REFERENCE_MANY;
                 $isRightCollection = isset($mapping['association'])
-                    && $mapping['association'] === ClassMetadataInfo::REFERENCE_MANY
+                    && $mapping['association'] === $association
                     && $mapping['targetDocument'] === $translationClass
                     && $mapping['mappedBy'] === 'object'
                 ;
@@ -88,7 +90,8 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
         }
         $q->setHydrate(false);
         $result = $q->execute();
-        if ($result instanceof Cursor) {
+        if (class_exists('Doctrine\ODM\MongoDB\Cursor') && $result instanceof Cursor ||
+            false === class_exists('Doctrine\ODM\MongoDB\Cursor')) {
             $result = $result->toArray();
         }
 
@@ -115,7 +118,8 @@ final class ODM extends BaseAdapterODM implements TranslatableAdapter
         }
         $q = $qb->getQuery();
         $result = $q->execute();
-        if ($result instanceof Cursor) {
+        if (class_exists('Doctrine\ODM\MongoDB\Cursor') && $result instanceof Cursor ||
+            false === class_exists('Doctrine\ODM\MongoDB\Cursor')) {
             $result = current($result->toArray());
         }
 

--- a/lib/Gedmo/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
+++ b/lib/Gedmo/Tree/Document/MongoDB/Repository/AbstractTreeRepository.php
@@ -2,15 +2,15 @@
 
 namespace Gedmo\Tree\Document\MongoDB\Repository;
 
-use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use Gedmo\MiddleManDocumentRepository;
 use Gedmo\Tree\RepositoryUtils;
 use Gedmo\Tree\RepositoryUtilsInterface;
 use Gedmo\Tree\RepositoryInterface;
 
-abstract class AbstractTreeRepository extends DocumentRepository implements RepositoryInterface
+abstract class AbstractTreeRepository extends MiddleManDocumentRepository implements RepositoryInterface
 {
     /**
      * Tree listener on event manager


### PR DESCRIPTION
This Pool Request add support for ODM 2.x who is provided by the package `doctrine/mongodb-odm`.
This PR doesn't drop support of ODM 1.x, it will check if classes exists.

By example, since in PHP7 the class `MongoRegex` doesn't exist anymore it will use the class `MongoDB\BSON\Regex` instead.