### PR TITLE
Added PHP 7 support for Doctrine ODM SoftDeletableFilter::addFilterCriteria().

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/ODM/SoftDeleteableFilter.php
@@ -19,7 +19,7 @@ class SoftDeleteableFilter extends BsonFilter
      *
      * @return array The criteria array, if there is available, empty array otherwise
      */
-    public function addFilterCriteria(ClassMetadata $targetEntity)
+    public function addFilterCriteria(ClassMetadata $targetEntity): array
     {
         $class = $targetEntity->getName();
         if (array_key_exists($class, $this->disabled) && $this->disabled[$class] === true) {


### PR DESCRIPTION
Added PHP 7 support for Doctrine ODM SoftDeletableFilter::addFilterCriteria().
This fix is necessary for using this filter on Doctrine Mongo ODM with PHP 7+