### PR TITLE
Regenerate slug if it is empty

### DIFF
--- a/lib/Gedmo/Sluggable/SluggableListener.php
+++ b/lib/Gedmo/Sluggable/SluggableListener.php
@@ -289,8 +289,8 @@ class SluggableListener extends MappedEventSubscriber
             $oldSlug = isset($changeSet[$slugField]) ? $changeSet[$slugField][0] : $slug;
             $needToChangeSlug = false;
 
-            // if slug is null, regenerate it, or needs an update
-            if (null === $slug || $slug === '__id__' || !isset($changeSet[$slugField])) {
+            // if slug is null or empty, regenerate it, or needs an update
+            if (null === $slug || '' === $slug || $slug === '__id__' || !isset($changeSet[$slugField])) {
                 $slug = '';
 
                 foreach ($options['fields'] as $sluggableField) {


### PR DESCRIPTION
This patch treats an empty slug like it was set to `null` so it gets regenerated automatically.