### PR TITLE
[Tree] The value of path source property is cast to string type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Tree
+### Fixed
+- The value of path source property is cast to string type for Materialized Path Tree strategy (#2061)
 
 ## [2.4.38] - 2019-11-08
 ### Global / Shared

--- a/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
+++ b/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php
@@ -244,7 +244,7 @@ abstract class AbstractMaterializedPath implements Strategy
         $pathProp->setAccessible(true);
         $pathSourceProp = $meta->getReflectionProperty($config['path_source']);
         $pathSourceProp->setAccessible(true);
-        $path = $pathSourceProp->getValue($node);
+        $path = (string) $pathSourceProp->getValue($node);
 
         // We need to avoid the presence of the path separator in the path source
         if (strpos($path, $config['path_separator']) !== false) {


### PR DESCRIPTION
Hi! During the migration to php7.4, we faced with an error. We use integer value as a tree path source and it causes this error: 

> Notice: Trying to access array offset on value of type int

on this line https://github.com/Atlantic18/DoctrineExtensions/blob/81681364331b131518060e4776300a5346df1eb5/lib/Gedmo/Tree/Strategy/AbstractMaterializedPath.php#L299