### PR TITLE
correction proposal on regex

### DIFF
--- a/src/Sluggable/Mapping/Event/Adapter/ODM.php
+++ b/src/Sluggable/Mapping/Event/Adapter/ODM.php
@@ -27,8 +27,7 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
         if (($identifier = $wrapped->getIdentifier()) && !$meta->isIdentifier($config['slug'])) {
             $qb->field($meta->identifier)->notEqual($identifier);
         }
-        $qb->field($config['slug'])->equals(new \MongoRegex('/^'.preg_quote($slug, '/').'/'));
-
+        $qb->field($config['slug'])->equals(new \MongoDB\BSON\Regex('^'.$slug));
         // use the unique_base to restrict the uniqueness check
         if ($config['unique'] && isset($config['unique_base'])) {
             if (is_object($ubase = $wrapped->getPropertyValue($config['unique_base']))) {
@@ -38,17 +37,11 @@ final class ODM extends BaseAdapterODM implements SluggableAdapter
             } else {
                 $qb->field($config['unique_base'])->equals(null);
             }
-        }
-
+        }        
         $q = $qb->getQuery();
-        $q->setHydrate(false);
-
+        $q->setHydrate(false);        
         $result = $q->execute();
-        if ($result instanceof Cursor) {
-            $result = $result->toArray();
-        }
-
-        return $result;
+        return $result->toArray();
     }
 
     /**


### PR DESCRIPTION
The Sluggable extension is inoperative because of the change made to the mongodb library. Using the MongoDB\BSON\Regex class it works fine on php7.3, mongodb 4.2 and symfony 4.4 environment (doctrine/mongodb-odm-bundle: ^4.1@dev)