### PR TITLE
Add deferred assignment support for the Blameable actor

### DIFF
--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -122,6 +122,15 @@ $treeListener = new Gedmo\Tree\TreeListener;
 $treeListener->setAnnotationReader($cachedAnnotationReader);
 $evm->addEventSubscriber($treeListener);
 
+// blameable
+$actor = new App\Actor(); // Extends Gedmo\Blameable\BlameableActorInterface
+$blameableListener = new Gedmo\Blameable\BlameableListener();
+$blameableListener->setAnnotationReader($cachedAnnotationReader);
+// Also can pass raw object or string to setActor, but using an Actor proxy object
+// allows for deferred actor assignment
+$blameableListener->setActor($actor);
+$eventManager->addEventSubscriber($blameableListener);
+
 // loggable, not used in example
 $loggableListener = new Gedmo\Loggable\LoggableListener;
 $loggableListener->setAnnotationReader($cachedAnnotationReader);

--- a/src/Blameable/BlameableActorInterface.php
+++ b/src/Blameable/BlameableActorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Gedmo\Blameable;
+
+/**
+ * Interface for Blameable extension's actor
+ *
+ * @author Jacob Thomason <jacob@rentpost.com>
+ */
+interface BlameableActorInterface
+{
+
+    /**
+     * Gets the actor value used for Blameable
+     *
+     * @return mixed
+     */
+    public function getActor();
+}

--- a/src/Blameable/BlameableListener.php
+++ b/src/Blameable/BlameableListener.php
@@ -18,7 +18,7 @@ use Gedmo\Blameable\Mapping\Event\BlameableAdapter;
  */
 class BlameableListener extends AbstractTrackingListener
 {
-    protected $user;
+    protected $actor;
 
     /**
      * Get the user value to set on a blameable field
@@ -31,35 +31,54 @@ class BlameableListener extends AbstractTrackingListener
     public function getFieldValue($meta, $field, $eventAdapter)
     {
         if ($meta->hasAssociation($field)) {
-            if (null !== $this->user && ! is_object($this->user)) {
+            if (null !== $this->actor && ! is_object($this->actor)) {
                 throw new InvalidArgumentException("Blame is reference, user must be an object");
             }
 
-            return $this->user;
+            return $this->actor;
         }
 
-        // ok so its not an association, then it is a string
-        if (is_object($this->user)) {
-            if (method_exists($this->user, 'getUsername')) {
-                return (string) $this->user->getUsername();
+        // Ok so its not an association, then it is a string
+        if (is_object($this->actor)) {
+            if ($this->actor instanceof BlameableActorInterface) {
+                return $this->actor->getActor();
             }
-            if (method_exists($this->user, '__toString')) {
-                return $this->user->__toString();
+
+            if (method_exists($this->actor, 'getUsername')) {
+                return (string) $this->actor->getUsername();
             }
+
+            if (method_exists($this->actor, '__toString')) {
+                return $this->actor->__toString();
+            }
+
             throw new InvalidArgumentException("Field expects string, user must be a string, or object should have method getUsername or __toString");
         }
 
-        return $this->user;
+        return $this->actor;
     }
 
     /**
      * Set a user value to return
      *
+     * @deprecated 2019/12/15 Replaced by setActor which is less opinionated
+     * @see setActor
+     *
      * @param mixed $user
      */
-    public function setUserValue($user)
+    public function setUserValue($actor)
     {
-        $this->user = $user;
+        $this->setActor($actor);
+    }
+
+    /**
+     * Sets the actor used for Blameable
+     *
+     * @param mixed $actor
+     */
+    public function setActor($actor)
+    {
+        $this->actor = $actor;
     }
 
     /**

--- a/src/Blameable/BlameableListener.php
+++ b/src/Blameable/BlameableListener.php
@@ -35,6 +35,10 @@ class BlameableListener extends AbstractTrackingListener
                 throw new InvalidArgumentException("Blame is reference, user must be an object");
             }
 
+            if ($this->actor instanceof BlameableActorInterface) {
+                return $this->actor->getActor();
+            }
+
             return $this->actor;
         }
 


### PR DESCRIPTION
An example Actor class that implements the new BlameableActorInterface

```php
<?php

class Actor implements BlameableActorInterface
{

    protected RoleStack $roleStack;


    /**
     * Constructor
     *
     * @param RoleStack $roleStack
     */
    public function __construct(RoleStack $roleStack)
    {
        $this->roleStack = $roleStack;
    }


    /**
     * Gets the actor/Role
     *
     * @return Role
     */
    public function getActor()
    {
        return $this->roleStack->top();
    }
}
```