### PR TITLE
Added new PR for existing PR 1868

### DIFF
--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -30,6 +30,13 @@ class SoftDeleteableListener extends MappedEventSubscriber
     const POST_SOFT_DELETE = "postSoftDelete";
 
     /**
+     * Objects soft-deleted on flush.
+     *
+     * @var array
+     */
+    private $softDeletedObjects = array();
+
+    /**
      * {@inheritdoc}
      */
     public function getSubscribedEvents()
@@ -37,6 +44,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
         return array(
             'loadClassMetadata',
             'onFlush',
+            'postFlush',
         );
     }
 
@@ -92,7 +100,28 @@ class SoftDeleteableListener extends MappedEventSubscriber
                     self::POST_SOFT_DELETE,
                     $ea->createLifecycleEventArgsInstance($object, $om)
                 );
+
+                $this->softDeletedObjects[] = $object;
             }
+        }
+    }
+
+    /**
+     * Detach soft-deleted objects from object manager.
+     *
+     * @param \Doctrine\Common\EventArgs $args
+     *
+     * @return void
+     *
+     * @throws \Gedmo\Exception\InvalidArgumentException
+     */
+    public function postFlush(EventArgs $args)
+    {
+        $ea = $this->getEventAdapter($args);
+        $om = $ea->getObjectManager();
+        foreach ($this->softDeletedObjects as $index => $object) {
+            $om->detach($object);
+            unset($this->softDeletedObjects[$index]);
         }
     }
 

--- a/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
+++ b/tests/Gedmo/SoftDeleteable/SoftDeleteableEntityTest.php
@@ -79,6 +79,23 @@ class SoftDeleteableEntityTest extends BaseTestCaseORM
     /**
      * @test
      */
+    public function shouldNotFetchSoftDeletedItemByIdIfDetachOnDeleteEnabled()
+    {
+        $repo = $this->em->getRepository(self::USER_CLASS);
+        $newUser = new User();
+        $newUser->setUsername('test_user');
+        $this->em->persist($newUser);
+        $this->em->flush();
+        $userId = $newUser->getId();
+        $this->em->remove($newUser);
+        $this->em->flush();
+        $user = $repo->find($userId);
+        $this->assertNull($user);
+    }
+
+    /**
+     * @test
+     */
     public function shouldSoftlyDeleteIfColumnNameDifferFromPropertyName()
     {
         $repo = $this->em->getRepository(self::USER_CLASS);


### PR DESCRIPTION
For some reason this PR, while saying that it was merged, didn't actually make it into the codebase.  This PR cleans up the OM postFlush, detaching the entity/object that was soft-deleted.

See the test for an example of why this is useful.