### PR TITLE
Add PHP 7.4 Compatibility to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
 
 env: MONGODB_SERVER=
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "doctrine/mongodb-odm": "^1.2",
         "doctrine/orm": "^2.6",
         "symfony/yaml": "^4.1",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^7.5"
     },
     "conflict": {
         "doctrine/annotations": "<1.2",

--- a/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseMongoODM.php
@@ -42,18 +42,6 @@ abstract class BaseTestCaseMongoODM extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
-    public function expectException($exception)
-    {
-        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
-            return parent::setExpectedException($exception);
-        }
-
-        return parent::expectException($exception);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function tearDown()
     {
         if ($this->dm) {

--- a/tests/Gedmo/Tool/BaseTestCaseOM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseOM.php
@@ -57,18 +57,6 @@ abstract class BaseTestCaseOM extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
-    public function expectException($exception)
-    {
-        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
-            return parent::setExpectedException($exception);
-        }
-
-        return parent::expectException($exception);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function tearDown()
     {
         foreach ($this->dms as $dm) {

--- a/tests/Gedmo/Tool/BaseTestCaseORM.php
+++ b/tests/Gedmo/Tool/BaseTestCaseORM.php
@@ -47,18 +47,6 @@ abstract class BaseTestCaseORM extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function expectException($exception)
-    {
-        if (method_exists('PHPUnit\\Framework\\TestCase', 'setExpectedException')) {
-            return parent::setExpectedException($exception);
-        }
-
-        return parent::expectException($exception);
-    }
-
-    /**
      * EntityManager mock object together with
      * annotation mapping driver and pdo_sqlite
      * database in memory

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./bootstrap.php"
 >
     <testsuites>


### PR DESCRIPTION
Starting off PHP 7.4 compatibility by adding it to Travis and seeing what the build result is.

If there are new errors or deprecations to be concerned about, we'll add focus on adding them to the `php7.4` branch.