### PR TITLE
[Uploadable] Update ALL file info when filename is generated, not only the filePath

### DIFF
--- a/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
+++ b/tests/Gedmo/Uploadable/Fixture/Entity/FileWithCustomFilenameGenerator.php
@@ -7,7 +7,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * @ORM\Entity
- * @Gedmo\Uploadable(pathMethod="getPath", filenameGenerator="Gedmo\Uploadable\FakeFilenameGenerator")
+ * @Gedmo\Uploadable(
+ *     pathMethod="getPath",
+ *     filenameGenerator="Gedmo\Uploadable\FakeFilenameGenerator",
+ *     appendNumber=true
+ * )
  */
 class FileWithCustomFilenameGenerator
 {

--- a/tests/Gedmo/Uploadable/UploadableEntityTest.php
+++ b/tests/Gedmo/Uploadable/UploadableEntityTest.php
@@ -377,19 +377,24 @@ class UploadableEntityTest extends BaseTestCaseORM
 
     public function testFileWithCustomFilenameGenerator()
     {
-        $file = new FileWithCustomFilenameGenerator();
-        $fileInfo = $this->generateUploadedFile();
+        $uploadFile = function($expected) {
+            $file = new FileWithCustomFilenameGenerator();
+            $fileInfo = $this->generateUploadedFile();
 
-        $this->listener->addEntityFileInfo($file, $fileInfo);
+            $this->listener->addEntityFileInfo($file, $fileInfo);
 
-        $this->em->persist($file);
-        $this->em->flush();
+            $this->em->persist($file);
+            $this->em->flush();
 
-        $this->em->refresh($file);
+            $this->em->refresh($file);
 
-        $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
+            $filename = substr($file->getFilePath(), strrpos($file->getFilePath(), '/') + 1);
 
-        $this->assertEquals('123.txt', $filename);
+            $this->assertEquals($expected, $filename);
+        };
+
+        $uploadFile('123.text');
+        $uploadFile('123-2.text');
     }
 
     public function testUploadFileWithoutExtension()
@@ -731,6 +736,6 @@ class FakeFilenameGenerator implements \Gedmo\Uploadable\FilenameGenerator\Filen
 {
     public static function generate($filename, $extension, $object = null)
     {
-        return '123.txt';
+        return '123.text';
     }
 }


### PR DESCRIPTION
I now made the problem clear with a modified test in the first commit.

Before my fix the test results in:

    Failed asserting that two strings are equal.
    Expected: '123-2.text'
    Actual: '123-2.txt'