### PR TITLE
[SoftDeleteable] Fix filter not invalidating Query cache

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/lib/Gedmo/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -72,6 +72,8 @@ class SoftDeleteableFilter extends SQLFilter
     public function disableForEntity($class)
     {
         $this->disabled[$class] = true;
+        // Make sure the hash (@see SQLFilter::__toString()) for this filter will be changed to invalidate the query cache.
+        $this->setParameter(sprintf('disabled_%s', $class), true);
     }
 
     /**
@@ -80,6 +82,8 @@ class SoftDeleteableFilter extends SQLFilter
     public function enableForEntity($class)
     {
         $this->disabled[$class] = false;
+        // Make sure the hash (@see SQLFilter::__toString()) for this filter will be changed to invalidate the query cache.
+        $this->setParameter(sprintf('disabled_%s', $class), false);
     }
 
     /**


### PR DESCRIPTION
When the query cache is enabled for the ORM entity manager, enabling or disabling the soft deleteable filter for an entity doesn't change the hash of the filter. Therefore, the result cannot change.

The only way to invalidate the query cache is to set a varying (depending of the entity enabled or disabled) boolean parameter (the hash of a filter is calculated by serializing the parameters: https://github.com/doctrine/orm/blob/8c259ea5cb632dbb57001b2262048ae7fa52b102/lib/Doctrine/ORM/Query/Filter/SQLFilter.php#L110-L113).

The first commit is a failing test to show the issue, the second one fixes it.