### PR TITLE
[SoftDeleteable] POC: Add ability to change default SoftDeleteable behavior

### DIFF
--- a/doc/softdeleteable.md
+++ b/doc/softdeleteable.md
@@ -12,6 +12,7 @@ Features:
 - Annotation, Yaml and Xml mapping support for extensions
 - Support for 'timeAware' option: When creating an entity set a date of deletion in the future and never worry about cleaning up at expiration time.
 - Support for 'hardDelete' option: When deleting a second time it allows to disable hard delete.
+- Support for 'disabled' option: When disabled is defined the filter uses it as the fallback behavior if `enableForEntity` or `disableForEntity` are not applied
 
 Content:
 
@@ -96,7 +97,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false, hardDelete=true)
+ * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false, hardDelete=true, disabled=true)
  */
 class Article
 {

--- a/src/Mapping/Annotation/SoftDeleteable.php
+++ b/src/Mapping/Annotation/SoftDeleteable.php
@@ -23,4 +23,7 @@ final class SoftDeleteable extends Annotation
 
     /** @var bool */
     public $hardDelete = true;
+
+    /** @var bool */
+    public $disabled;
 }

--- a/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
+++ b/src/SoftDeleteable/Filter/SoftDeleteableFilter.php
@@ -41,13 +41,17 @@ class SoftDeleteableFilter extends SQLFilter
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
         $class = $targetEntity->getName();
+        $config = $this->getListener()->getConfiguration($this->getEntityManager(), $class);
+
+        if (!isset($this->disabled[$class]) && isset($config['disabled'])) {
+            $this->disabled[$class] = $config['disabled'];
+        }
+
         if (array_key_exists($class, $this->disabled) && true === $this->disabled[$class]) {
             return '';
         } elseif (array_key_exists($targetEntity->rootEntityName, $this->disabled) && true === $this->disabled[$targetEntity->rootEntityName]) {
             return '';
         }
-
-        $config = $this->getListener()->getConfiguration($this->getEntityManager(), $targetEntity->name);
 
         if (!isset($config['softDeleteable']) || !$config['softDeleteable']) {
             return '';

--- a/src/SoftDeleteable/Mapping/Driver/Annotation.php
+++ b/src/SoftDeleteable/Mapping/Driver/Annotation.php
@@ -52,6 +52,13 @@ class Annotation extends AbstractAnnotationDriver
                 }
                 $config['hardDelete'] = $annot->hardDelete;
             }
+
+            if (isset($annot->disabled)) {
+                if (!is_bool($annot->disabled)) {
+                    throw new InvalidMappingException("disabled must be boolean. ".gettype($annot->disabled)." provided.");
+                }
+                $config['disabled'] = $annot->hardDelete;
+            }
         }
 
         $this->validateFullMetadata($meta, $config);


### PR DESCRIPTION
Here is the case: if we want to soft delete some entity, but it should be visible in the related entities. We can disable filter in ALL those places and only when show list of this entities the disabled will be hidden. But this POC add ability to reverse this behavior when there are too many places to refactor. For example we have `User` entity. `User` entity is also used all across the system and we don't want to change the behavior and hide it if the some user will be soft deleted. We want him to be shown in logs, orders, etc. But we don't want to show him in the list of users and we don't want to modify the query for that by the hands. We can add `disabled=true` to the annotation and it still be shown in all relations (though it is soft deleteable). And in the list of users we'll use 
```php
$filter = $em->getFilters()->getFilter('soft_deleteable');
$filter->enableForEntity(User::class);
```
to hide all soft deleted entities