### PR TITLE
[SoftDeleteable] Add support for non-\DateTime fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,4 +39,4 @@ a release.
 
 ### SoftDeleteable
 #### Fixed
-- Fixed support for non-\DateTime fields
+- Added support for non-\DateTime fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,7 @@ a release.
 ### Tree
 #### Fixed
 - The value of path source property is cast to string type for Materialized Path Tree strategy (#2061)
+
+### SoftDeleteable
+#### Fixed
+- Fixed support for non-\DateTime fields

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
@@ -2,8 +2,9 @@
 
 namespace Gedmo\SoftDeleteable\Mapping\Event\Adapter;
 
-use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
+use Gedmo\Mapping\Event\Adapter\ODM as BaseAdapterODM;
 use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
+use Gedmo\Timestampable\Mapping\Event\TimestampableAdapter;
 
 /**
  * Doctrine event adapter for ORM adapted
@@ -12,15 +13,15 @@ use Gedmo\SoftDeleteable\Mapping\Event\SoftDeleteableAdapter;
  * @author David Buchmann <mail@davidbu.ch>
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
+final class ODM extends BaseAdapterODM implements SoftDeleteableAdapter
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDateValue($meta, $field)
     {
         $mapping = $meta->getFieldMapping($field);
-        if (isset($mapping['type']) && 'integer' === $mapping['type']) {
+        if (isset($mapping['type']) && 'timestamp' === $mapping['type']) {
             return time();
         }
         if (isset($mapping['type']) && 'zenddate' == $mapping['type']) {

--- a/src/SoftDeleteable/Mapping/Event/SoftDeleteableAdapter.php
+++ b/src/SoftDeleteable/Mapping/Event/SoftDeleteableAdapter.php
@@ -13,4 +13,13 @@ use Gedmo\Mapping\Event\AdapterInterface;
  */
 interface SoftDeleteableAdapter extends AdapterInterface
 {
+    /**
+     * Get the date value
+     *
+     * @param object $meta
+     * @param string $field
+     *
+     * @return mixed
+     */
+    public function getDateValue($meta, $field);
 }

--- a/src/SoftDeleteable/SoftDeleteableListener.php
+++ b/src/SoftDeleteable/SoftDeleteableListener.php
@@ -61,7 +61,7 @@ class SoftDeleteableListener extends MappedEventSubscriber
             if (isset($config['softDeleteable']) && $config['softDeleteable']) {
                 $reflProp = $meta->getReflectionProperty($config['fieldName']);
                 $oldValue = $reflProp->getValue($object);
-                $date = new \DateTime();
+                $date = $ea->getDateValue($meta, $config['fieldName']);
 
                 // Remove `$oldValue instanceof \DateTime` check when PHP version is bumped to >=5.5
                 if (isset($config['hardDelete']) && $config['hardDelete'] && ($oldValue instanceof \DateTime || $oldValue instanceof \DateTimeInterface) && $oldValue <= $date) {


### PR DESCRIPTION
While Timestampable has nice support for many types of date-fields, it was lacking in SoftDeleteable. In this PR, I reuse the logic already available in the Timestampable extension to provide the timestamp in the SoftDeleteable for the database field.