### PR TITLE
[Tree] [NestedSet] fixes and enhancements

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -24,10 +24,10 @@ Thanks for contributions to:
 
 Update **2018-02-26**
 
-- Nodes with no Parent can now be sorted based on a tree root id being an id from another table. Existing behaviour 
-  is unchanged unless you add properties to the `@TreeRoot` annotation. Example: You have two categories with no parent, 
-  horror and comedy, which are actually categories of 'Movie', which is in another table. Usually calling `moveUp()` or 
-  `moveDown()` would be impossible, but now you can add `@TreeRoot(identifierMethod="getRoot")`, where `getRoot` is the 
+- Nodes with no Parent can now be sorted based on a tree root id being an id from another table. Existing behaviour
+  is unchanged unless you add properties to the `@TreeRoot` annotation. Example: You have two categories with no parent,
+  horror and comedy, which are actually categories of 'Movie', which is in another table. Usually calling `moveUp()` or
+  `moveDown()` would be impossible, but now you can add `@TreeRoot(identifierMethod="getRoot")`, where `getRoot` is the
   name of your class method returning the root id/entity.
 
 
@@ -1334,7 +1334,7 @@ There are repository methods that are available for you in all the strategies:
       * nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
       * rootOpen: string || Closure ('\<ul\>') - branch start, closure will be given $children as a parameter
       * rootClose: string ('\</ul\>') - branch close
-      * childStart: string || Closure ('\<li\>') - start of node, closure will be given $node as a parameter
+      * childOpen: string || Closure ('\<li\>') - start of node, closure will be given $node as a parameter
       * childClose: string ('\</li\>') - close of node
       * childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
   - *includeNode*: Using "true", this argument allows you to include in the result the node you passed as the first argument. Defaults to "false".

--- a/src/Mapping/Annotation/TreeLevel.php
+++ b/src/Mapping/Annotation/TreeLevel.php
@@ -15,4 +15,10 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class TreeLevel extends Annotation
 {
+    /**
+     * The level which root nodes will have
+     *
+     * @var integer
+     */
+    public $base = 0;
 }

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -243,12 +243,9 @@ class NestedTreeRepository extends AbstractTreeRepository
         if (!$sortByField) {
             $qb->orderBy('node.'.$config['left'], 'ASC');
         } elseif (is_array($sortByField)) {
-            $fields = '';
-            foreach ($sortByField as $field) {
-                $fields .= 'node.'.$field.',';
+            foreach ($sortByField as $key => $field) {
+                $qb->addOrderBy('node.'.$field, is_array($direction) ? $direction[$key] : $direction);
             }
-            $fields = rtrim($fields, ',');
-            $qb->orderBy($fields, $direction);
         } else {
             if ($meta->hasField($sortByField) && in_array(strtolower($direction), ['asc', 'desc'])) {
                 $qb->orderBy('node.'.$sortByField, $direction);

--- a/src/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/src/Tree/Entity/Repository/NestedTreeRepository.php
@@ -790,7 +790,7 @@ class NestedTreeRepository extends AbstractTreeRepository
      * @param string      $sortByField - field name to sort by
      * @param string      $direction   - sort direction : "ASC" or "DESC"
      * @param bool        $verify      - true to verify tree first
-     * @param boolean     $recursive   - true to also reorder grandchildren recursively
+     * @param bool        $recursive   - true to also reorder grandchildren recursively
      *
      * @return bool|null
      */

--- a/src/Tree/Mapping/Driver/Annotation.php
+++ b/src/Tree/Mapping/Driver/Annotation.php
@@ -166,7 +166,7 @@ class Annotation extends AbstractAnnotationDriver
                 $config['root'] = $field;
             }
             // level
-            if ($this->reader->getPropertyAnnotation($property, self::LEVEL)) {
+            if ($levelAnnotation = $this->reader->getPropertyAnnotation($property, self::LEVEL)) {
                 $field = $property->getName();
                 if (!$meta->hasField($field)) {
                     throw new InvalidMappingException("Unable to find 'level' - [{$field}] as mapped property in entity - {$meta->name}");
@@ -175,6 +175,7 @@ class Annotation extends AbstractAnnotationDriver
                     throw new InvalidMappingException("Tree level field - [{$field}] type is not valid and must be 'integer' in class - {$meta->name}");
                 }
                 $config['level'] = $field;
+                $config['level_base'] = (int) $levelAnnotation->base;
             }
             // path
             if ($pathAnnotation = $this->reader->getPropertyAnnotation($property, self::PATH)) {

--- a/src/Tree/RepositoryUtilsInterface.php
+++ b/src/Tree/RepositoryUtilsInterface.php
@@ -18,7 +18,7 @@ interface RepositoryUtilsInterface
      *                            nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
      *                            rootOpen: string || Closure ('<ul>') - branch start, closure will be given $children as a parameter
      *                            rootClose: string ('</ul>') - branch close
-     *                            childStart: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
+     *                            childOpen: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
      *                            childClose: string ('</li>') - close of node
      *                            childSort: array || keys allowed: field: field to sort on, dir: direction. 'asc' or 'desc'
      * @param bool   $includeNode - Include node on results?
@@ -41,7 +41,7 @@ interface RepositoryUtilsInterface
      *                       nodeDecorator: Closure (null) - uses $node as argument and returns decorated item as string
      *                       rootOpen: string || Closure ('<ul>') - branch start, closure will be given $children as a parameter
      *                       rootClose: string ('</ul>') - branch close
-     *                       childStart: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
+     *                       childOpen: string || Closure ('<li>') - start of node, closure will be given $node as a parameter
      *                       childClose: string ('</li>') - close of node
      *
      * @return array|string

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -275,8 +275,7 @@ class Nested implements Strategy
     }
 
     /**
-     * Update the $node with a diferent $parent
-     * destination
+     * Update the $node with a different $parent destination
      *
      * @param object $node     - target node
      * @param object $parent   - destination node
@@ -309,7 +308,7 @@ class Nested implements Strategy
         if (isset($this->nodePositions[$oid])) {
             $position = $this->nodePositions[$oid];
         }
-        $level = 0;
+        $level = isset($config['level_base']) ? $config['level_base'] : 0;
         $treeSize = $right - $left + 1;
         $newRoot = null;
         if ($parent) {    // || (!$parent && isset($config['rootIdentifierMethod']))

--- a/tests/Gedmo/Tree/Fixture/RootCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootCategory.php
@@ -51,7 +51,7 @@ class RootCategory
     private $root;
 
     /**
-     * @Gedmo\TreeLevel
+     * @Gedmo\TreeLevel(base=1)
      * @ORM\Column(name="lvl", type="integer")
      */
     private $level;

--- a/tests/Gedmo/Tree/NestedTreePositionTest.php
+++ b/tests/Gedmo/Tree/NestedTreePositionTest.php
@@ -81,7 +81,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $meat = $repo->findOneBy(['title' => 'Meat']);
 
-        $this->assertEquals(2, $oranges->getLevel());
+        $this->assertEquals(3, $oranges->getLevel());
         $this->assertEquals(7, $oranges->getLeft());
         $this->assertEquals(8, $oranges->getRight());
 
@@ -105,7 +105,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
 
         $this->assertEquals(9, $meat_array[0]['c_lft']);
         $this->assertEquals(10, $meat_array[0]['c_rgt']);
-        $this->assertEquals(2, $meat_array[0]['c_level']);
+        $this->assertEquals(3, $meat_array[0]['c_level']);
     }
 
     public function testTreeChildPositionMove3()
@@ -116,7 +116,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $milk = $repo->findOneBy(['title' => 'Milk']);
 
-        $this->assertEquals(2, $oranges->getLevel());
+        $this->assertEquals(3, $oranges->getLevel());
         $this->assertEquals(7, $oranges->getLeft());
         $this->assertEquals(8, $oranges->getRight());
 
@@ -136,7 +136,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $milk_array = $this->em->createQuery($dql)->getScalarResult();
         $this->assertEquals(9, $milk_array[0]['c_lft']);
         $this->assertEquals(10, $milk_array[0]['c_rgt']);
-        $this->assertEquals(2, $milk_array[0]['c_level']);
+        $this->assertEquals(3, $milk_array[0]['c_level']);
     }
 
     public function testPositionedUpdates()
@@ -177,12 +177,12 @@ class NestedTreePositionTest extends BaseTestCaseORM
         $oranges = $repo->findOneBy(['title' => 'Oranges']);
         $fruits = $repo->findOneBy(['title' => 'Fruits']);
 
-        $this->assertEquals(2, $oranges->getLevel());
+        $this->assertEquals(3, $oranges->getLevel());
 
         $repo->persistAsNextSiblingOf($oranges, $fruits);
         $this->em->flush();
 
-        $this->assertEquals(1, $oranges->getLevel());
+        $this->assertEquals(2, $oranges->getLevel());
         $this->assertCount(1, $repo->children($fruits, true));
 
         $vegies = $repo->findOneBy(['title' => 'Vegitables']);
@@ -230,7 +230,7 @@ class NestedTreePositionTest extends BaseTestCaseORM
 
         $this->em->flush();
         $dql = 'SELECT COUNT(c) FROM '.self::ROOT_CATEGORY.' c';
-        $dql .= ' WHERE c.lft = 1 AND c.rgt = 2 AND c.parent IS NULL AND c.level = 0';
+        $dql .= ' WHERE c.lft = 1 AND c.rgt = 2 AND c.parent IS NULL AND c.level = 1';
         $count = $this->em->createQuery($dql)->getSingleScalarResult();
         $this->assertEquals(6, $count);
 

--- a/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootRepositoryTest.php
@@ -332,6 +332,41 @@ class NestedTreeRootRepositoryTest extends BaseTestCaseORM
         $this->assertEquals(9, $onions->getLeft());
         $this->assertEquals(10, $onions->getRight());
 
+        // reorder (non-recursive)
+
+        $node = $repo->findOneByTitle('Food');
+        $repo->reorder($node, 'title', 'DESC', false, false);
+
+        $node = $repo->findOneByTitle('Vegitables');
+
+        $this->assertEquals(2, $node->getLeft());
+        $this->assertEquals(11, $node->getRight());
+
+        $node = $repo->findOneByTitle('Fruits');
+
+        $this->assertEquals(12, $node->getLeft());
+        $this->assertEquals(13, $node->getRight());
+
+        $node = $repo->findOneByTitle('Carrots');
+
+        $this->assertEquals(3, $node->getLeft());
+        $this->assertEquals(4, $node->getRight());
+
+        $node = $repo->findOneByTitle('Potatoes');
+
+        $this->assertEquals(5, $node->getLeft());
+        $this->assertEquals(6, $node->getRight());
+
+        $node = $repo->findOneByTitle('Onions');
+
+        $this->assertEquals(7, $node->getLeft());
+        $this->assertEquals(8, $node->getRight());
+
+        $node = $repo->findOneByTitle('Cabbages');
+
+        $this->assertEquals(9, $node->getLeft());
+        $this->assertEquals(10, $node->getRight());
+
         // reorder
 
         $node = $repo->findOneBy(['title' => 'Food']);

--- a/tests/Gedmo/Tree/NestedTreeRootTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootTest.php
@@ -110,42 +110,42 @@ class NestedTreeRootTest extends BaseTestCaseORM
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(1, $node->getLeft());
-        $this->assertEquals(0, $node->getLevel());
+        $this->assertEquals(1, $node->getLevel());
         $this->assertEquals(10, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Sports']);
 
         $this->assertEquals(2, $node->getRoot());
         $this->assertEquals(1, $node->getLeft());
-        $this->assertEquals(0, $node->getLevel());
+        $this->assertEquals(1, $node->getLevel());
         $this->assertEquals(2, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Fruits']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(2, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(4, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(9, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Carrots']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(5, $node->getLeft());
-        $this->assertEquals(2, $node->getLevel());
+        $this->assertEquals(3, $node->getLevel());
         $this->assertEquals(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(7, $node->getLeft());
-        $this->assertEquals(2, $node->getLevel());
+        $this->assertEquals(3, $node->getLevel());
         $this->assertEquals(8, $node->getRight());
     }
 
@@ -163,7 +163,7 @@ class NestedTreeRootTest extends BaseTestCaseORM
         $this->assertEquals(4, $node->getRoot());
         $this->assertEquals(1, $node->getLeft());
         $this->assertEquals(6, $node->getRight());
-        $this->assertEquals(0, $node->getLevel());
+        $this->assertEquals(1, $node->getLevel());
     }
 
     public function testTreeUpdateShiftToNextBranch()
@@ -186,7 +186,7 @@ class NestedTreeRootTest extends BaseTestCaseORM
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(2, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
@@ -214,14 +214,14 @@ class NestedTreeRootTest extends BaseTestCaseORM
 
         $this->assertEquals(4, $node->getRoot());
         $this->assertEquals(1, $node->getLeft());
-        $this->assertEquals(0, $node->getLevel());
+        $this->assertEquals(1, $node->getLevel());
         $this->assertEquals(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         $this->assertEquals(4, $node->getRoot());
         $this->assertEquals(4, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(5, $node->getRight());
     }
 
@@ -245,14 +245,14 @@ class NestedTreeRootTest extends BaseTestCaseORM
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(2, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Potatoes']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(7, $node->getLeft());
-        $this->assertEquals(2, $node->getLevel());
+        $this->assertEquals(3, $node->getLevel());
         $this->assertEquals(8, $node->getRight());
     }
 
@@ -289,21 +289,21 @@ class NestedTreeRootTest extends BaseTestCaseORM
 
         $this->assertEquals(4, $node->getRoot());
         $this->assertEquals(2, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(3, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Vegitables']);
 
         $this->assertEquals(4, $node->getRoot());
         $this->assertEquals(1, $node->getLeft());
-        $this->assertEquals(0, $node->getLevel());
+        $this->assertEquals(1, $node->getLevel());
         $this->assertEquals(6, $node->getRight());
 
         $node = $repo->findOneBy(['title' => 'Sports']);
 
         $this->assertEquals(1, $node->getRoot());
         $this->assertEquals(2, $node->getLeft());
-        $this->assertEquals(1, $node->getLevel());
+        $this->assertEquals(2, $node->getLevel());
         $this->assertEquals(3, $node->getRight());
     }
 

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -88,6 +88,24 @@ class RepositoryTest extends BaseTestCaseORM
 
         $this->assertCount(6, $children);
 
+        // test children sorting
+
+        $children = $this->em->getRepository(self::CATEGORY)
+             ->children($food, true, ['title'], 'ASC');
+
+        $this->assertCount(2, $children);
+        $this->assertEquals('Fruits', $children[0]->getTitle());
+        $this->assertEquals('Vegitables', $children[1]->getTitle());
+
+        $children = $this->em->getRepository(self::CATEGORY)
+             ->children($food, false, ['level', 'title'], ['ASC', 'DESC']);
+
+        $this->assertCount(4, $children);
+        $this->assertEquals('Vegitables', $children[0]->getTitle());
+        $this->assertEquals('Fruits', $children[1]->getTitle());
+        $this->assertEquals('Potatoes', $children[2]->getTitle());
+        $this->assertEquals('Carrots', $children[3]->getTitle());
+
         // path
 
         $path = $this->em->getRepository(self::CATEGORY)

--- a/tests/Gedmo/Tree/RepositoryTest.php
+++ b/tests/Gedmo/Tree/RepositoryTest.php
@@ -294,7 +294,7 @@ class RepositoryTest extends BaseTestCaseORM
         // now lets brake something
 
         $dql = 'UPDATE '.self::CATEGORY.' node';
-        $dql .= ' SET node.lft = 1';
+        $dql .= ' SET node.lft = 1, node.level = 99';
         $dql .= ' WHERE node.id = 8';
         $q = $this->em->createQuery($dql);
         $q->getSingleScalarResult();
@@ -309,14 +309,17 @@ class RepositoryTest extends BaseTestCaseORM
         $this->assertArrayHasKey(0, $result);
         $this->assertArrayHasKey(1, $result);
         $this->assertArrayHasKey(2, $result);
+        $this->assertArrayHasKey(3, $result);
 
         $duplicate = $result[0];
         $missing = $result[1];
         $invalidLeft = $result[2];
+        $invalidLevel = $result[3];
 
         $this->assertEquals('index [1], duplicate', $duplicate);
         $this->assertEquals('index [11], missing', $missing);
         $this->assertEquals('node [8] left is less than parent`s [4] left value', $invalidLeft);
+        $this->assertEquals('node [8] should be on the level right after its parent`s [4] level', $invalidLevel);
 
         // test recover functionality
         $repo->recover();


### PR DESCRIPTION
- Added and fixed some wrong comments
- Verify and recover wrong levels in nested set
- childrenQueryBuilder() to allow specifying sort order separately for each field
- Added option to reorder only direct children in reorder() method
- Added 'includeNode' option in getPathQueryBuilder() to specify whether you want the starting node included or not
- Added 'base' property for tree level annotation
- Added 'treeRootNode' options in verify() in case you want to verify a single tree in a forest
- Added options to recover() for sibling order, tree root in a forest, verification skip and auto-flushing
- Added recoverFast() method for where speed is more important than safety and entity manager state
- Added getPathAsString() method to entity repository
