### PR TITLE
Remove duplicate root definition from XML mapping

### DIFF
--- a/doc/tree.md
+++ b/doc/tree.md
@@ -317,9 +317,6 @@ Entity\Category:
         <field name="right" column="rgt" type="integer">
             <gedmo:tree-right/>
         </field>
-        <field name="root" type="integer" nullable="true">
-            <gedmo:tree-root/>
-        </field>
         <field name="level" column="lvl" type="integer">
             <gedmo:tree-level/>
         </field>


### PR DESCRIPTION
This links to the following commit: https://github.com/Atlantic18/DoctrineExtensions/pull/1777
Where `root` was removed from the yaml example but not from the XML one.
