### PR TITLE
[Sluggable] Remove interpreted annotations from phpdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ a release.
 ---
 
 ## [Unreleased]
+### Sluggable
+#### Fixed
+- Remove PHPDoc samples as they are interpreted by Annotation Reader.
 
 ## [2.4.40] - 2020-04-27
 ### SoftDeleteable

--- a/lib/Gedmo/Mapping/Annotation/SlugHandler.php
+++ b/lib/Gedmo/Mapping/Annotation/SlugHandler.php
@@ -7,18 +7,6 @@ use Doctrine\Common\Annotations\Annotation;
 /**
  * SlugHandler annotation for Sluggable behavioral extension
  *
- * @Gedmo\Slug(handlers={
- *      @Gedmo\SlugHandler(class="Some\Class", options={
- *          @Gedmo\SlugHandlerOption(name="relation", value="parent"),
- *          @Gedmo\SlugHandlerOption(name="separator", value="/")
- *      }),
- *      @Gedmo\SlugHandler(class="Some\Class", options={
- *          @Gedmo\SlugHandlerOption(name="option", value="val"),
- *          ...
- *      }),
- *      ...
- * }, separator="-", updatable=false)
- *
  * @Annotation
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>

--- a/lib/Gedmo/Mapping/Annotation/SlugHandlerOption.php
+++ b/lib/Gedmo/Mapping/Annotation/SlugHandlerOption.php
@@ -7,18 +7,6 @@ use Doctrine\Common\Annotations\Annotation;
 /**
  * SlugHandlerOption annotation for Sluggable behavioral extension
  *
- * @Gedmo\Slug(handlers={
- *      @Gedmo\SlugHandler(class="Some\Class", options={
- *          @Gedmo\SlugHandlerOption(name="relation", value="parent"),
- *          @Gedmo\SlugHandlerOption(name="separator", value="/")
- *      }),
- *      @Gedmo\SlugHandler(class="Some\Class", options={
- *          @Gedmo\SlugHandlerOption(name="option", value="val"),
- *          ...
- *      }),
- *      ...
- * }, separator="-", updatable=false)
- *
  * @Annotation
  *
  * @author Gediminas Morkevicius <gediminas.morkevicius@gmail.com>


### PR DESCRIPTION
I had an issue with these samples as they are interpreted by Donctrine Annotation Reader.
I use the library (2.4.39) with antishov/doctrine-extensions-bundle in a Symfony 4.4 environment which require to load all annotation mapping by configuration even if they are not used.
I get the following error when running the schema drop command.

```
In AnnotationException.php line 54:

  [Semantical Error] Annotation @Gedmo\Slug is not allowed to be declared on class Gedmo\Mapping\Annotation\SlugHandler. You may only use this annotation on these code elements: PROPERTY.
```

I choose to remove the examples here are they are also provided in the documentation section.

Hopefully a new release will be published soon with this fix as my project will run in production shortly :slightly_smiling_face: 
Also, note that the 2.4.40 release on github is not present in packagist.

Thank you!