### PR TITLE
Fix verify left & right checks as int

### DIFF
--- a/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
+++ b/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php
@@ -1004,7 +1004,7 @@ class NestedTreeRepository extends AbstractTreeRepository
             $left = $meta->getReflectionProperty($config['left'])->getValue($node);
             $id = $meta->getReflectionProperty($identifier)->getValue($node);
             $parent = $meta->getReflectionProperty($config['parent'])->getValue($node);
-            if (!$right || !$left) {
+            if (!is_int($right) || !is_int($left)) {
                 $errors[] = "node [{$id}] has invalid left or right values";
             } elseif ($right == $left) {
                 $errors[] = "node [{$id}] has identical left and right values";


### PR DESCRIPTION
## Problem
There is an issue when we verify a tree with multiple roots.
`node [2] has invalid left or right values`

## Context
PHP 7.2

Build a tree just with one root element in the table:
| id     	| root    	| level 	| left 	| right 	| parent_id |
|--------	|---------	|-------	|------	|-------	|-------	  |
| 1      	| 1       	| 0     	| -1   	| 0     	| NULL       |

```php
$repo = $this->doctrine->getRepository('My\Entity\Tree');
$repo->verify();
```
At [this line](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php#L1007) , the check does not pass because `left = -1` and `right = 0`
```php
// NestedTreeRepository.php::verifyTree()
...
if (!$right || !$left) {
```

## Remarks
This issue looks to me so general, so maybe I have done something wrong, if you know please comment.



