### PR TITLE
Allow composite identifiers in loggable

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -2,12 +2,12 @@
 
 namespace Gedmo\Loggable\Entity\Repository;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Gedmo\Loggable\Entity\LogEntry;
-use Gedmo\Tool\Wrapper\EntityWrapper;
-use Doctrine\ORM\EntityRepository;
 use Gedmo\Loggable\LoggableListener;
+use Gedmo\Tool\Wrapper\EntityWrapper;
 
 /**
  * The LogEntryRepository has some useful functions
@@ -56,7 +56,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.objectClass = :objectClass";
         $dql .= " ORDER BY log.version DESC";
 
-        $objectId = (string) $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass'));
 
@@ -88,7 +88,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.version <= :version";
         $dql .= " ORDER BY log.version ASC";
 
-        $objectId = (string) $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass', 'version'));
         $logs = $q->getResult();
@@ -127,7 +127,7 @@ class LogEntryRepository extends EntityRepository
         if (!$objectMeta->isSingleValuedAssociation($field)) {
             return;
         }
-        
+
         $mapping = $objectMeta->getAssociationMapping($field);
         $value   = $value ? $this->_em->getReference($mapping['targetEntity'], $value) : null;
     }

--- a/lib/Gedmo/Loggable/LoggableListener.php
+++ b/lib/Gedmo/Loggable/LoggableListener.php
@@ -3,8 +3,8 @@
 namespace Gedmo\Loggable;
 
 use Doctrine\Common\EventArgs;
-use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
+use Gedmo\Mapping\MappedEventSubscriber;
 use Gedmo\Tool\Wrapper\AbstractWrapper;
 
 /**
@@ -136,7 +136,7 @@ class LoggableListener extends MappedEventSubscriber
             $logEntry = $this->pendingLogEntryInserts[$oid];
             $logEntryMeta = $om->getClassMetadata(get_class($logEntry));
 
-            $id = $wrapped->getIdentifier();
+            $id = $wrapped->getIdentifier(false, true);
             $logEntryMeta->getReflectionProperty('objectId')->setValue($logEntry, $id);
             $uow->scheduleExtraUpdate($logEntry, array(
                 'objectId' => array(null, $id),
@@ -286,10 +286,10 @@ class LoggableListener extends MappedEventSubscriber
 
             // check for the availability of the primary key
             $uow = $om->getUnitOfWork();
-            if ($action === self::ACTION_CREATE && $ea->isPostInsertGenerator($meta)) {
+            if ($action === self::ACTION_CREATE && ($ea->isPostInsertGenerator($meta) || ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->isIdentifierComposite))) {
                 $this->pendingLogEntryInserts[spl_object_hash($object)] = $logEntry;
             } else {
-                $logEntry->setObjectId($wrapped->getIdentifier());
+                $logEntry->setObjectId($wrapped->getIdentifier(false, true));
             }
             $newValues = array();
             if ($action !== self::ACTION_REMOVE && isset($config['versioned'])) {

--- a/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Annotation.php
@@ -33,7 +33,10 @@ class Annotation extends AbstractAnnotationDriver
      */
     public function validateFullMetadata(ClassMetadata $meta, array $config)
     {
-        if ($config && is_array($meta->identifier) && count($meta->identifier) > 1) {
+        if ($config && $meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+        }
+        if ($config && $meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
             throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
         }
         if (isset($config['versioned']) && !isset($config['loggable'])) {
@@ -82,7 +85,10 @@ class Annotation extends AbstractAnnotationDriver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if ($this->isClassAnnotationInValid($meta, $config)) {

--- a/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Xml.php
@@ -65,7 +65,10 @@ class Xml extends BaseXml
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if (isset($config['versioned']) && !isset($config['loggable'])) {

--- a/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
+++ b/lib/Gedmo/Loggable/Mapping/Driver/Yaml.php
@@ -116,7 +116,10 @@ class Yaml extends File implements Driver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if (isset($config['versioned']) && !isset($config['loggable'])) {

--- a/lib/Gedmo/Loggable/Mapping/Event/Adapter/ORM.php
+++ b/lib/Gedmo/Loggable/Mapping/Event/Adapter/ORM.php
@@ -2,8 +2,10 @@
 
 namespace Gedmo\Loggable\Mapping\Event\Adapter;
 
+use Doctrine\ORM\Utility\IdentifierFlattener;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
+use Gedmo\Tool\Wrapper\EntityWrapper;
 
 /**
  * Doctrine event adapter for ORM adapted
@@ -37,8 +39,8 @@ final class ORM extends BaseAdapterORM implements LoggableAdapter
     {
         $em = $this->getObjectManager();
         $objectMeta = $em->getClassMetadata(get_class($object));
-        $identifierField = $this->getSingleIdentifierFieldName($objectMeta);
-        $objectId = (string) $objectMeta->getReflectionProperty($identifierField)->getValue($object);
+        $wrapper = new EntityWrapper($object, $em);
+        $objectId = $wrapper->getIdentifier(false, true);
 
         $dql = "SELECT MAX(log.version) FROM {$meta->name} log";
         $dql .= " WHERE log.objectId = :objectId";

--- a/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/EntityWrapper.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tool\Wrapper;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
 
@@ -81,33 +82,31 @@ class EntityWrapper extends AbstractWrapper
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier($single = true)
+    public function getIdentifier($single = true, $flatten = false)
     {
         if (null === $this->identifier) {
-            if ($this->object instanceof Proxy) {
-                $uow = $this->om->getUnitOfWork();
-                if ($uow->isInIdentityMap($this->object)) {
-                    $this->identifier = $uow->getEntityIdentifier($this->object);
-                } else {
-                    $this->initialize();
-                }
-            }
-            if (null === $this->identifier) {
-                $this->identifier = array();
-                $incomplete = false;
-                foreach ($this->meta->identifier as $name) {
-                    $this->identifier[$name] = $this->getPropertyValue($name);
-                    if (null === $this->identifier[$name]) {
-                        $incomplete = true;
-                    }
-                }
-                if ($incomplete) {
-                    $this->identifier = null;
-                }
+            $uow = $this->om->getUnitOfWork();
+            $this->identifier = $uow->isInIdentityMap($this->object)
+                ? $uow->getEntityIdentifier($this->object)
+                : $this->meta->getIdentifierValues($this->object);
+            if ((is_array($this->identifier) && empty($this->identifier))) {
+                $this->identifier = null;
             }
         }
-        if ($single && is_array($this->identifier)) {
-            return reset($this->identifier);
+        if (is_array($this->identifier)) {
+            if ($single) {
+                return reset($this->identifier);
+            }
+            if ($flatten) {
+                $id = $this->identifier;
+                foreach ($id as $i => $value) {
+                    if (is_object($value) && $this->om->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($value))) {
+                        $id[$i] = (new EntityWrapper($value, $this->om))->getIdentifier(false, true);
+                    }
+                }
+
+                return implode(' ', $id);
+            }
         }
 
         return $this->identifier;

--- a/lib/Gedmo/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/lib/Gedmo/Tool/Wrapper/MongoDocumentWrapper.php
@@ -81,7 +81,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier($single = true)
+    public function getIdentifier($single = true, $flatten = false)
     {
         if (!$this->identifier) {
             if ($this->object instanceof Proxy) {

--- a/lib/Gedmo/Tool/WrapperInterface.php
+++ b/lib/Gedmo/Tool/WrapperInterface.php
@@ -64,10 +64,11 @@ interface WrapperInterface
      * Get the object identifier, single or composite
      *
      * @param boolean $single
+     * @param boolean $flatten
      *
      * @return array|mixed
      */
-    public function getIdentifier($single = true);
+    public function getIdentifier($single = true, $flatten = false);
 
     /**
      * Get root object class name

--- a/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Loggable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class Composite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(length=128)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function __construct($one, $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+}

--- a/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Loggable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class CompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    private $articleOne;
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    private $articleTwo;
+
+    /**
+     * @ORM\Column(length=128)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function __construct(Article $articleOne, Article $articleTwo)
+    {
+        $this->articleOne = $articleOne;
+        $this->articleTwo = $articleTwo;
+    }
+
+    public function getArticleOne()
+    {
+        return $this->articleOne;
+    }
+
+    public function getArticleTwo()
+    {
+        return $this->articleTwo;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+}

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -7,6 +7,8 @@ use Tool\BaseTestCaseORM;
 use Doctrine\Common\EventManager;
 use Loggable\Fixture\Entity\Address;
 use Loggable\Fixture\Entity\Article;
+use Loggable\Fixture\Entity\Composite;
+use Loggable\Fixture\Entity\CompositeRelation;
 use Loggable\Fixture\Entity\RelatedArticle;
 use Loggable\Fixture\Entity\Comment;
 use Loggable\Fixture\Entity\Geo;
@@ -21,6 +23,8 @@ use Loggable\Fixture\Entity\Geo;
 class LoggableEntityTest extends BaseTestCaseORM
 {
     const ARTICLE = 'Loggable\Fixture\Entity\Article';
+    const COMPOSITE = 'Loggable\Fixture\Entity\Composite';
+    const COMPOSITE_RELATION = 'Loggable\Fixture\Entity\CompositeRelation';
     const COMMENT = 'Loggable\Fixture\Entity\Comment';
     const RELATED_ARTICLE = 'Loggable\Fixture\Entity\RelatedArticle';
     const COMMENT_LOG = 'Loggable\Fixture\Entity\Log\Comment';
@@ -151,17 +155,128 @@ class LoggableEntityTest extends BaseTestCaseORM
         $this->assertCount(5, $logEntries[3]->getData());
     }
 
+    public function testComposite()
+    {
+        $logRepo = $this->em->getRepository('Gedmo\Loggable\Entity\LogEntry');
+        $compositeRepo = $this->em->getRepository(self::COMPOSITE);
+        $this->assertCount(0, $logRepo->findAll());
+
+        $cmp0 = new Composite(1, 2);
+        $cmp0->setTitle('Title2');
+
+        $this->em->persist($cmp0);
+        $this->em->flush();
+
+        $cmpId = sprintf('%s %s', 1, 2);
+
+        $log = $logRepo->findOneByObjectId($cmpId);
+
+        $this->assertNotNull($log);
+        $this->assertEquals('create', $log->getAction());
+        $this->assertEquals(get_class($cmp0), $log->getObjectClass());
+        $this->assertEquals('jules', $log->getUsername());
+        $this->assertEquals(1, $log->getVersion());
+        $data = $log->getData();
+        $this->assertCount(1, $data);
+        $this->assertArrayHasKey('title', $data);
+        $this->assertEquals($data['title'], 'Title2');
+
+        // test update
+        $composite = $compositeRepo->findOneByTitle('Title2');
+
+        $composite->setTitle('New');
+        $this->em->persist($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $log = $logRepo->findOneBy(array('version' => 2, 'objectId' => $cmpId));
+        $this->assertEquals('update', $log->getAction());
+
+        // test delete
+        $composite = $compositeRepo->findOneByTitle('New');
+        $this->em->remove($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $log = $logRepo->findOneBy(array('version' => 3, 'objectId' => $cmpId));
+        $this->assertEquals('remove', $log->getAction());
+        $this->assertNull($log->getData());
+    }
+
+    public function testCompositeRelation()
+    {
+        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
+        }
+        $logRepo = $this->em->getRepository('Gedmo\Loggable\Entity\LogEntry');
+        $compositeRepo = $this->em->getRepository(self::COMPOSITE_RELATION);
+        $this->assertCount(0, $logRepo->findAll());
+
+        $art0 = new Article();
+        $art0->setTitle('Title0');
+        $art1 = new Article();
+        $art1->setTitle('Title1');
+        $cmp0 = new CompositeRelation($art0, $art1);
+        $cmp0->setTitle('Title2');
+
+        $this->em->persist($art0);
+        $this->em->persist($art1);
+        $this->em->persist($cmp0);
+        $this->em->flush();
+
+        $cmpId = sprintf('%s %s', $art0->getId(), $art1->getId());
+
+        $log = $logRepo->findOneByObjectId($cmpId);
+
+        $this->assertNotNull($log);
+        $this->assertEquals('create', $log->getAction());
+        $this->assertEquals(get_class($cmp0), $log->getObjectClass());
+        $this->assertEquals('jules', $log->getUsername());
+        $this->assertEquals(1, $log->getVersion());
+        $data = $log->getData();
+        $this->assertCount(1, $data);
+        $this->assertArrayHasKey('title', $data);
+        $this->assertEquals($data['title'], 'Title2');
+
+        // test update
+        $composite = $compositeRepo->findOneByTitle('Title2');
+
+        $composite->setTitle('New');
+        $this->em->persist($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $log = $logRepo->findOneBy(array('version' => 2, 'objectId' => $cmpId));
+        $this->assertEquals('update', $log->getAction());
+
+        // test delete
+        $composite = $compositeRepo->findOneByTitle('New');
+        $this->em->remove($composite);
+        $this->em->flush();
+        $this->em->clear();
+
+        $log = $logRepo->findOneBy(array('version' => 3, 'objectId' => $cmpId));
+        $this->assertEquals('remove', $log->getAction());
+        $this->assertNull($log->getData());
+    }
+
     protected function getUsedEntityFixtures()
     {
-        return array(
+        $usedEntityFixtures = array(
             self::ARTICLE,
             self::COMMENT,
             self::COMMENT_LOG,
             self::RELATED_ARTICLE,
+            self::COMPOSITE,
             'Gedmo\Loggable\Entity\LogEntry',
             'Loggable\Fixture\Entity\Address',
             'Loggable\Fixture\Entity\Geo',
         );
+        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
+            $usedEntityFixtures[] = self::COMPOSITE_RELATION;
+        }
+
+        return $usedEntityFixtures;
     }
 
     private function populateEmbedded()

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableComposite.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableComposite.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="Mapping\Fixture\Xml\LoggableComposite" table="loggables_with_composite">
+
+        <id name="one" type="integer" column="one"/>
+        <id name="two" type="integer" column="two"/>
+
+        <field name="title" type="string" length="128">
+            <gedmo:versioned/>
+        </field>
+
+        <gedmo:loggable log-entry-class="Gedmo\Loggable\Entity\LogEntry"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableCompositeRelation.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableCompositeRelation.dcm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="Mapping\Fixture\Xml\LoggableCompositeRelation" table="loggables_with_composite_relation">
+
+        <id name="one" association-key="true"/>
+        <id name="two" type="integer" column="two"/>
+
+        <field name="title" type="string" length="128">
+            <gedmo:versioned/>
+        </field>
+
+        <many-to-one field="one" target-entity="Loggable"/>
+
+        <gedmo:loggable log-entry-class="Gedmo\Loggable\Entity\LogEntry"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Loggable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Loggable.dcm.yml
@@ -1,0 +1,18 @@
+---
+Mapping\Fixture\Yaml\Loggable:
+  type: entity
+  table: loggable
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableComposite.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableComposite.dcm.yml
@@ -1,0 +1,18 @@
+---
+Mapping\Fixture\Yaml\LoggableComposite:
+  type: entity
+  table: loggable_with_composite
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    one:
+      type: integer
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableCompositeRelation.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableCompositeRelation.dcm.yml
@@ -1,0 +1,21 @@
+---
+Mapping\Fixture\Yaml\LoggableCompositeRelation:
+  type: entity
+  table: loggable_with_composite_relation
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    one:
+      associationKey: true
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+  manyToOne:
+    one:
+      targetEntity: Loggable
+

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class Loggable
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class LoggableComposite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class LoggableCompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Loggable")
+     */
+    private $one;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Xml;
+
+class LoggableComposite
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Xml;
+
+class LoggableCompositeRelation
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class Loggable
+{
+    private $id;
+
+    private $title;
+
+    private $status;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class LoggableComposite
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class LoggableCompositeRelation
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
@@ -19,6 +19,9 @@ use Tool\BaseTestCaseOM;
  */
 class LoggableMappingTest extends BaseTestCaseOM
 {
+    const COMPOSITE = 'Mapping\\Fixture\\Xml\\LoggableComposite';
+    const COMPOSITE_RELATION = 'Mapping\\Fixture\\Xml\\LoggableCompositeRelation';
+
     /**
      * @var Doctrine\ORM\EntityManager
      */
@@ -69,6 +72,51 @@ class LoggableMappingTest extends BaseTestCaseOM
         $this->assertCount(2, $config['versioned']);
         $this->assertContains('title', $config['versioned']);
         $this->assertContains('status', $config['versioned']);
+    }
+
+    public function testLoggableCompositeMetadata()
+    {
+        $meta = $this->em->getClassMetadata(self::COMPOSITE);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @expectedException \Gedmo\Exception\InvalidMappingException
+     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
+     */
+    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
+    {
+        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM < 2.6 version required for this test.');
+        }
+        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+    }
+
+    public function testLoggableCompositeRelationMetadata()
+    {
+        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
+        }
+        $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
     }
 
     public function testLoggableMetadataWithEmbedded()

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wrapper\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Composite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    public function __construct($one, $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wrapper\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Wrapper\Fixture\Entity\Article")
+     */
+    private $article;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $status;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    public function __construct(Article $articleOne, $status)
+    {
+        $this->article = $articleOne;
+        $this->status = $status;
+    }
+
+    public function getArticle()
+    {
+        return $this->article;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}


### PR DESCRIPTION
Composite identifiers with foreign entities availaible for ORM > 2.6 due to earlier version not handling identifiers for newly inserted foreign objects