### PR TITLE
[Loggable] Allow composite identifiers

### DIFF
--- a/src/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/src/Loggable/Entity/Repository/LogEntryRepository.php
@@ -56,7 +56,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= ' AND log.objectClass = :objectClass';
         $dql .= ' ORDER BY log.version DESC';
 
-        $objectId = (string) $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass'));
 
@@ -88,7 +88,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= ' AND log.version <= :version';
         $dql .= ' ORDER BY log.version ASC';
 
-        $objectId = (string) $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier(false, true);
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass', 'version'));
         $logs = $q->getResult();

--- a/src/Loggable/LoggableListener.php
+++ b/src/Loggable/LoggableListener.php
@@ -131,7 +131,7 @@ class LoggableListener extends MappedEventSubscriber
             $logEntry = $this->pendingLogEntryInserts[$oid];
             $logEntryMeta = $om->getClassMetadata(get_class($logEntry));
 
-            $id = $wrapped->getIdentifier();
+            $id = $wrapped->getIdentifier(false, true);
             $logEntryMeta->getReflectionProperty('objectId')->setValue($logEntry, $id);
             $uow->scheduleExtraUpdate($logEntry, [
                 'objectId' => [null, $id],
@@ -277,10 +277,10 @@ class LoggableListener extends MappedEventSubscriber
 
             // check for the availability of the primary key
             $uow = $om->getUnitOfWork();
-            if (self::ACTION_CREATE === $action && $ea->isPostInsertGenerator($meta)) {
+            if (self::ACTION_CREATE === $action && ($ea->isPostInsertGenerator($meta) || ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->isIdentifierComposite))) {
                 $this->pendingLogEntryInserts[spl_object_hash($object)] = $logEntry;
             } else {
-                $logEntry->setObjectId($wrapped->getIdentifier());
+                $logEntry->setObjectId($wrapped->getIdentifier(false, true));
             }
             $newValues = [];
             if (self::ACTION_REMOVE !== $action && isset($config['versioned'])) {

--- a/src/Loggable/Mapping/Driver/Annotation.php
+++ b/src/Loggable/Mapping/Driver/Annotation.php
@@ -33,9 +33,6 @@ class Annotation extends AbstractAnnotationDriver
      */
     public function validateFullMetadata(ClassMetadata $meta, array $config)
     {
-        if ($config && $meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-            throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
-        }
         if ($config && $meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
             throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
         }
@@ -85,9 +82,6 @@ class Annotation extends AbstractAnnotationDriver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
-            }
             if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }

--- a/src/Loggable/Mapping/Driver/Annotation.php
+++ b/src/Loggable/Mapping/Driver/Annotation.php
@@ -33,7 +33,10 @@ class Annotation extends AbstractAnnotationDriver
      */
     public function validateFullMetadata(ClassMetadata $meta, array $config)
     {
-        if ($config && is_array($meta->identifier) && count($meta->identifier) > 1) {
+        if ($config && $meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+        }
+        if ($config && $meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
             throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
         }
         if (isset($config['versioned']) && !isset($config['loggable'])) {
@@ -82,7 +85,10 @@ class Annotation extends AbstractAnnotationDriver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if ($this->isClassAnnotationInValid($meta, $config)) {

--- a/src/Loggable/Mapping/Driver/Xml.php
+++ b/src/Loggable/Mapping/Driver/Xml.php
@@ -65,9 +65,6 @@ class Xml extends BaseXml
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
-            }
             if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }

--- a/src/Loggable/Mapping/Driver/Xml.php
+++ b/src/Loggable/Mapping/Driver/Xml.php
@@ -65,7 +65,10 @@ class Xml extends BaseXml
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if (isset($config['versioned']) && !isset($config['loggable'])) {

--- a/src/Loggable/Mapping/Driver/Yaml.php
+++ b/src/Loggable/Mapping/Driver/Yaml.php
@@ -117,7 +117,10 @@ class Yaml extends File implements Driver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if (is_array($meta->identifier) && count($meta->identifier) > 1) {
+            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
+            }
+            if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }
             if (isset($config['versioned']) && !isset($config['loggable'])) {

--- a/src/Loggable/Mapping/Driver/Yaml.php
+++ b/src/Loggable/Mapping/Driver/Yaml.php
@@ -117,9 +117,6 @@ class Yaml extends File implements Driver
         }
 
         if (!$meta->isMappedSuperclass && $config) {
-            if ($meta instanceof \Doctrine\ORM\Mapping\ClassMetadata && $meta->containsForeignIdentifier && is_array($meta->identifier) && count($meta->identifier) > 1 && 1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-                throw new InvalidMappingException("Loggable does not support composite foreign identifiers with ORM < 2.6");
-            }
             if ($meta instanceof \Doctrine\ODM\MongoDB\Mapping\ClassMetadata && is_array($meta->identifier) && count($meta->identifier) > 1) {
                 throw new InvalidMappingException("Loggable does not support composite identifiers in class - {$meta->name}");
             }

--- a/src/Loggable/Mapping/Event/Adapter/ORM.php
+++ b/src/Loggable/Mapping/Event/Adapter/ORM.php
@@ -4,6 +4,7 @@ namespace Gedmo\Loggable\Mapping\Event\Adapter;
 
 use Gedmo\Loggable\Mapping\Event\LoggableAdapter;
 use Gedmo\Mapping\Event\Adapter\ORM as BaseAdapterORM;
+use Gedmo\Tool\Wrapper\EntityWrapper;
 
 /**
  * Doctrine event adapter for ORM adapted
@@ -37,8 +38,8 @@ final class ORM extends BaseAdapterORM implements LoggableAdapter
     {
         $em = $this->getObjectManager();
         $objectMeta = $em->getClassMetadata(get_class($object));
-        $identifierField = $this->getSingleIdentifierFieldName($objectMeta);
-        $objectId = (string) $objectMeta->getReflectionProperty($identifierField)->getValue($object);
+        $wrapper = new EntityWrapper($object, $em);
+        $objectId = $wrapper->getIdentifier(false, true);
 
         $dql = "SELECT MAX(log.version) FROM {$meta->name} log";
         $dql .= ' WHERE log.objectId = :objectId';

--- a/src/Tool/Wrapper/EntityWrapper.php
+++ b/src/Tool/Wrapper/EntityWrapper.php
@@ -2,6 +2,7 @@
 
 namespace Gedmo\Tool\Wrapper;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
 
@@ -80,33 +81,31 @@ class EntityWrapper extends AbstractWrapper
     /**
      * {@inheritdoc}
      */
-    public function getIdentifier($single = true)
+    public function getIdentifier($single = true, $flatten = false)
     {
         if (null === $this->identifier) {
-            if ($this->object instanceof Proxy) {
-                $uow = $this->om->getUnitOfWork();
-                if ($uow->isInIdentityMap($this->object)) {
-                    $this->identifier = $uow->getEntityIdentifier($this->object);
-                } else {
-                    $this->initialize();
-                }
-            }
-            if (null === $this->identifier) {
-                $this->identifier = [];
-                $incomplete = false;
-                foreach ($this->meta->identifier as $name) {
-                    $this->identifier[$name] = $this->getPropertyValue($name);
-                    if (null === $this->identifier[$name]) {
-                        $incomplete = true;
-                    }
-                }
-                if ($incomplete) {
-                    $this->identifier = null;
-                }
+            $uow = $this->om->getUnitOfWork();
+            $this->identifier = $uow->isInIdentityMap($this->object)
+                ? $uow->getEntityIdentifier($this->object)
+                : $this->meta->getIdentifierValues($this->object);
+            if ((is_array($this->identifier) && empty($this->identifier))) {
+                $this->identifier = null;
             }
         }
-        if ($single && is_array($this->identifier)) {
-            return reset($this->identifier);
+        if (is_array($this->identifier)) {
+            if ($single) {
+                return reset($this->identifier);
+            }
+            if ($flatten) {
+                $id = $this->identifier;
+                foreach ($id as $i => $value) {
+                    if (is_object($value) && $this->om->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($value))) {
+                        $id[$i] = (new EntityWrapper($value, $this->om))->getIdentifier(false, true);
+                    }
+                }
+
+                return implode(' ', $id);
+            }
         }
 
         return $this->identifier;

--- a/src/Tool/Wrapper/MongoDocumentWrapper.php
+++ b/src/Tool/Wrapper/MongoDocumentWrapper.php
@@ -80,7 +80,7 @@ class MongoDocumentWrapper extends AbstractWrapper
     /**
      * {@inheritdoc}
      */
-    public function getIdentifier($single = true)
+    public function getIdentifier($single = true, $flatten = false)
     {
         if (!$this->identifier) {
             if ($this->object instanceof Proxy) {

--- a/src/Tool/WrapperInterface.php
+++ b/src/Tool/WrapperInterface.php
@@ -62,10 +62,11 @@ interface WrapperInterface
      * Get the object identifier, single or composite
      *
      * @param bool $single
+     * @param bool $flatten
      *
      * @return array|mixed
      */
-    public function getIdentifier($single = true);
+    public function getIdentifier($single = true, $flatten = false);
 
     /**
      * Get root object class name

--- a/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/Composite.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Loggable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class Composite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(length=128)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function __construct($one, $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+}

--- a/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Loggable/Fixture/Entity/CompositeRelation.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Loggable\Fixture\Entity;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class CompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    private $articleOne;
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Article")
+     */
+    private $articleTwo;
+
+    /**
+     * @ORM\Column(length=128)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function __construct(Article $articleOne, Article $articleTwo)
+    {
+        $this->articleOne = $articleOne;
+        $this->articleTwo = $articleTwo;
+    }
+
+    public function getArticleOne()
+    {
+        return $this->articleOne;
+    }
+
+    public function getArticleTwo()
+    {
+        return $this->articleTwo;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+}

--- a/tests/Gedmo/Loggable/LoggableEntityTest.php
+++ b/tests/Gedmo/Loggable/LoggableEntityTest.php
@@ -207,9 +207,6 @@ class LoggableEntityTest extends BaseTestCaseORM
 
     public function testCompositeRelation()
     {
-        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
-        }
         $logRepo = $this->em->getRepository('Gedmo\Loggable\Entity\LogEntry');
         $compositeRepo = $this->em->getRepository(self::COMPOSITE_RELATION);
         $this->assertCount(0, $logRepo->findAll());
@@ -264,21 +261,17 @@ class LoggableEntityTest extends BaseTestCaseORM
 
     protected function getUsedEntityFixtures()
     {
-        $usedEntityFixtures = [
+        return [
             self::ARTICLE,
             self::COMMENT,
             self::COMMENT_LOG,
             self::RELATED_ARTICLE,
             self::COMPOSITE,
+            self::COMPOSITE_RELATION,
             'Gedmo\Loggable\Entity\LogEntry',
             'Loggable\Fixture\Entity\Address',
             'Loggable\Fixture\Entity\Geo',
         ];
-        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
-            $usedEntityFixtures[] = self::COMPOSITE_RELATION;
-        }
-
-        return $usedEntityFixtures;
     }
 
     private function populateEmbedded()

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableComposite.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableComposite.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="Mapping\Fixture\Xml\LoggableComposite" table="loggables_with_composite">
+
+        <id name="one" type="integer" column="one"/>
+        <id name="two" type="integer" column="two"/>
+
+        <field name="title" type="string" length="128">
+            <gedmo:versioned/>
+        </field>
+
+        <gedmo:loggable log-entry-class="Gedmo\Loggable\Entity\LogEntry"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableCompositeRelation.dcm.xml
+++ b/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableCompositeRelation.dcm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+
+    <entity name="Mapping\Fixture\Xml\LoggableCompositeRelation" table="loggables_with_composite_relation">
+
+        <id name="one" association-key="true"/>
+        <id name="two" type="integer" column="two"/>
+
+        <field name="title" type="string" length="128">
+            <gedmo:versioned/>
+        </field>
+
+        <many-to-one field="one" target-entity="Loggable"/>
+
+        <gedmo:loggable log-entry-class="Gedmo\Loggable\Entity\LogEntry"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Loggable.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.Loggable.dcm.yml
@@ -1,0 +1,18 @@
+---
+Mapping\Fixture\Yaml\Loggable:
+  type: entity
+  table: loggable
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    id:
+      type: integer
+      generator:
+        strategy: AUTO
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableComposite.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableComposite.dcm.yml
@@ -1,0 +1,18 @@
+---
+Mapping\Fixture\Yaml\LoggableComposite:
+  type: entity
+  table: loggable_with_composite
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    one:
+      type: integer
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+

--- a/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableCompositeRelation.dcm.yml
+++ b/tests/Gedmo/Mapping/Driver/Yaml/Mapping.Fixture.Yaml.LoggableCompositeRelation.dcm.yml
@@ -1,0 +1,21 @@
+---
+Mapping\Fixture\Yaml\LoggableCompositeRelation:
+  type: entity
+  table: loggable_with_composite_relation
+  gedmo:
+    loggable:
+      logEntryClass: Gedmo\Loggable\Entity\LogEntry
+  id:
+    one:
+      associationKey: true
+    two:
+      type: integer
+  fields:
+    title:
+      type: string
+      gedmo:
+        - versioned
+  manyToOne:
+    one:
+      targetEntity: Loggable
+

--- a/tests/Gedmo/Mapping/Fixture/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Loggable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class Loggable
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableComposite.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class LoggableComposite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/LoggableCompositeRelation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mapping\Fixture;
+
+use Gedmo\Mapping\Annotation as Gedmo;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @Gedmo\Loggable
+ */
+class LoggableCompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Loggable")
+     */
+    private $one;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     * @Gedmo\Versioned
+     */
+    private $title;
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableComposite.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Xml;
+
+class LoggableComposite
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Xml/LoggableCompositeRelation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Xml;
+
+class LoggableCompositeRelation
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/Loggable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class Loggable
+{
+    private $id;
+
+    private $title;
+
+    private $status;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableComposite.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class LoggableComposite
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
+++ b/tests/Gedmo/Mapping/Fixture/Yaml/LoggableCompositeRelation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mapping\Fixture\Yaml;
+
+class LoggableCompositeRelation
+{
+    private $one;
+
+    private $two;
+
+    private $title;
+}

--- a/tests/Gedmo/Mapping/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableMappingTest.php
@@ -83,23 +83,8 @@ class LoggableMappingTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($config['loggable']);
     }
 
-    /**
-     * @expectedException \Gedmo\Exception\InvalidMappingException
-     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
-     */
-    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
-    {
-        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM < 2.6 version required for this test.');
-        }
-        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
-    }
-
     public function testLoggableCompositeRelationMapping()
     {
-        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
-        }
         $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
 
         $this->assertTrue(is_array($meta->identifier));

--- a/tests/Gedmo/Mapping/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/LoggableMappingTest.php
@@ -18,6 +18,8 @@ use Gedmo\Mapping\ExtensionMetadataFactory;
 class LoggableMappingTest extends \PHPUnit\Framework\TestCase
 {
     const YAML_CATEGORY = 'Mapping\Fixture\Yaml\Category';
+    const COMPOSITE = 'Mapping\Fixture\LoggableComposite';
+    const COMPOSITE_RELATION = 'Mapping\Fixture\LoggableCompositeRelation';
     private $em;
 
     public function setUp(): void
@@ -31,6 +33,15 @@ class LoggableMappingTest extends \PHPUnit\Framework\TestCase
         $chainDriverImpl->addDriver(
             new YamlDriver([__DIR__.'/Driver/Yaml']),
             'Mapping\Fixture\Yaml'
+        );
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace(
+            'Gedmo\\Mapping\\Annotation',
+            VENDOR_PATH.'/../lib'
+        );
+        $chainDriverImpl->addDriver(
+            new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($reader),
+            'Mapping\Fixture'
         );
         $config->setMetadataDriverImpl($chainDriverImpl);
 
@@ -56,5 +67,48 @@ class LoggableMappingTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($config['loggable']);
         $this->assertArrayHasKey('logEntryClass', $config);
         $this->assertEquals('Gedmo\\Loggable\\Entity\\LogEntry', $config['logEntryClass']);
+    }
+
+    public function testLoggableCompositeMapping()
+    {
+        $meta = $this->em->getClassMetadata(self::COMPOSITE);
+
+        $this->assertTrue(is_array($meta->identifier));
+        $this->assertCount(2, $meta->identifier);
+
+        $cacheId = ExtensionMetadataFactory::getCacheId(self::COMPOSITE, 'Gedmo\Loggable');
+        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+    }
+
+    /**
+     * @expectedException \Gedmo\Exception\InvalidMappingException
+     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
+     */
+    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
+    {
+        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM < 2.6 version required for this test.');
+        }
+        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+    }
+
+    public function testLoggableCompositeRelationMapping()
+    {
+        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
+        }
+        $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+
+        $this->assertTrue(is_array($meta->identifier));
+        $this->assertCount(2, $meta->identifier);
+
+        $cacheId = ExtensionMetadataFactory::getCacheId(self::COMPOSITE_RELATION, 'Gedmo\Loggable');
+        $config = $this->em->getMetadataFactory()->getCacheDriver()->fetch($cacheId);
+
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
     }
 }

--- a/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
@@ -21,6 +21,9 @@ use Tool\BaseTestCaseOM;
  */
 class LoggableMappingTest extends BaseTestCaseOM
 {
+    const COMPOSITE = 'Mapping\\Fixture\\Xml\\LoggableComposite';
+    const COMPOSITE_RELATION = 'Mapping\\Fixture\\Xml\\LoggableCompositeRelation';
+
     /**
      * @var Doctrine\ORM\EntityManager
      */
@@ -71,6 +74,51 @@ class LoggableMappingTest extends BaseTestCaseOM
         $this->assertCount(2, $config['versioned']);
         $this->assertContains('title', $config['versioned']);
         $this->assertContains('status', $config['versioned']);
+    }
+
+    public function testLoggableCompositeMetadata()
+    {
+        $meta = $this->em->getClassMetadata(self::COMPOSITE);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @expectedException \Gedmo\Exception\InvalidMappingException
+     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
+     */
+    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
+    {
+        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM < 2.6 version required for this test.');
+        }
+        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+    }
+
+    public function testLoggableCompositeRelationMetadata()
+    {
+        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
+        }
+        $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
     }
 
     public function testLoggableMetadataWithEmbedded()

--- a/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Xml/LoggableMappingTest.php
@@ -91,23 +91,8 @@ class LoggableMappingTest extends BaseTestCaseOM
         $this->assertContains('title', $config['versioned']);
     }
 
-    /**
-     * @expectedException \Gedmo\Exception\InvalidMappingException
-     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
-     */
-    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
-    {
-        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM < 2.6 version required for this test.');
-        }
-        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
-    }
-
     public function testLoggableCompositeRelationMetadata()
     {
-        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
-        }
         $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
         $config = $this->loggable->getConfiguration($this->em, $meta->name);
 

--- a/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
@@ -73,23 +73,8 @@ class LoggableMappingTest extends BaseTestCaseOM
         $this->assertContains('title', $config['versioned']);
     }
 
-    /**
-     * @expectedException \Gedmo\Exception\InvalidMappingException
-     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
-     */
-    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
-    {
-        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM < 2.6 version required for this test.');
-        }
-        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
-    }
-
     public function testLoggableCompositeRelationMetadata()
     {
-        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
-            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
-        }
         $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
         $config = $this->loggable->getConfiguration($this->em, $meta->name);
 

--- a/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
+++ b/tests/Gedmo/Mapping/Yaml/LoggableMappingTest.php
@@ -21,6 +21,9 @@ use Tool\BaseTestCaseOM;
  */
 class LoggableMappingTest extends BaseTestCaseOM
 {
+    const COMPOSITE = 'Mapping\Fixture\Yaml\LoggableComposite';
+    const COMPOSITE_RELATION = 'Mapping\Fixture\Yaml\LoggableCompositeRelation';
+
     /**
      * @var Doctrine\ORM\EntityManager
      */
@@ -53,6 +56,51 @@ class LoggableMappingTest extends BaseTestCaseOM
             'Mapping\Fixture\Yaml\LoggableWithEmbedded',
             'Mapping\Fixture\Yaml\Embedded',
         ], $chain);
+    }
+
+    public function testLoggableCompositeMetadata()
+    {
+        $meta = $this->em->getClassMetadata(self::COMPOSITE);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
+    }
+
+    /**
+     * @expectedException \Gedmo\Exception\InvalidMappingException
+     * @expectedExceptionMessage Loggable does not support composite foreign identifiers with ORM < 2.6
+     */
+    public function testORMBelow26ThrowsExceptionWithLoggableCompositeRelationMapping()
+    {
+        if (1 > \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM < 2.6 version required for this test.');
+        }
+        $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+    }
+
+    public function testLoggableCompositeRelationMetadata()
+    {
+        if (1 === \Doctrine\ORM\Version::compare('2.6.0')) {
+            $this->markTestSkipped('ORM >= 2.6 version required for this test.');
+        }
+        $meta = $this->em->getClassMetadata(self::COMPOSITE_RELATION);
+        $config = $this->loggable->getConfiguration($this->em, $meta->name);
+
+        $this->assertArrayHasKey('logEntryClass', $config);
+        $this->assertEquals('Gedmo\Loggable\Entity\LogEntry', $config['logEntryClass']);
+        $this->assertArrayHasKey('loggable', $config);
+        $this->assertTrue($config['loggable']);
+
+        $this->assertArrayHasKey('versioned', $config);
+        $this->assertCount(1, $config['versioned']);
+        $this->assertContains('title', $config['versioned']);
     }
 
     public function testLoggableMetadataWithEmbedded()

--- a/tests/Gedmo/Wrapper/EntityWrapperTest.php
+++ b/tests/Gedmo/Wrapper/EntityWrapperTest.php
@@ -6,6 +6,8 @@ use Doctrine\Common\EventManager;
 use Gedmo\Tool\Wrapper\EntityWrapper;
 use Tool\BaseTestCaseORM;
 use Wrapper\Fixture\Entity\Article;
+use Wrapper\Fixture\Entity\Composite;
+use Wrapper\Fixture\Entity\CompositeRelation;
 
 /**
  * Entity wrapper tests
@@ -19,6 +21,8 @@ use Wrapper\Fixture\Entity\Article;
 class EntityWrapperTest extends BaseTestCaseORM
 {
     const ARTICLE = 'Wrapper\\Fixture\\Entity\\Article';
+    const COMPOSITE = 'Wrapper\\Fixture\\Entity\\Composite';
+    const COMPOSITE_RELATION = 'Wrapper\\Fixture\\Entity\\CompositeRelation';
 
     protected function setUp(): void
     {
@@ -57,6 +61,47 @@ class EntityWrapperTest extends BaseTestCaseORM
         $this->assertEquals('test', $wrapped->getPropertyValue('title'));
     }
 
+    public function testComposite()
+    {
+        $test = $this->em->getReference(self::COMPOSITE, ['one' => 1, 'two' => 2]);
+        $this->assertInstanceOf(self::COMPOSITE, $test);
+        $wrapped = new EntityWrapper($test, $this->em);
+
+        $id = $wrapped->getIdentifier(false);
+        $this->assertTrue(is_array($id));
+        $this->assertCount(2, $id);
+        $this->assertArrayHasKey('one', $id);
+        $this->assertArrayHasKey('two', $id);
+        $this->assertEquals(1, $id['one']);
+        $this->assertEquals(2, $id['two']);
+
+        $id = $wrapped->getIdentifier(false, true);
+        $this->assertTrue(is_string($id));
+        $this->assertEquals('1 2', $id);
+
+        $this->assertEquals('test', $wrapped->getPropertyValue('title'));
+    }
+
+    public function testCompositeRelation()
+    {
+        $art1 = $this->em->getReference(self::ARTICLE, ['id' => 1]);
+        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => $art1->getId(), 'status' => 2]);
+        $this->assertInstanceOf(self::COMPOSITE_RELATION, $test);
+        $wrapped = new EntityWrapper($test, $this->em);
+
+        $id = $wrapped->getIdentifier(false);
+        $this->assertTrue(is_array($id));
+        $this->assertCount(2, $id);
+        $this->assertArrayHasKey('article', $id);
+        $this->assertArrayHasKey('status', $id);
+
+        $id = $wrapped->getIdentifier(false, true);
+        $this->assertTrue(is_string($id));
+        $this->assertEquals('1 2', $id);
+
+        $this->assertEquals('test', $wrapped->getPropertyValue('title'));
+    }
+
     public function testDetachedEntity()
     {
         $test = $this->em->find(self::ARTICLE, ['id' => 1]);
@@ -77,6 +122,28 @@ class EntityWrapperTest extends BaseTestCaseORM
         $this->assertEquals('test', $wrapped->getPropertyValue('title'));
     }
 
+    public function testDetachedCompositeRelation()
+    {
+        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => 1, 'status' => 2]);
+        $this->em->clear();
+        $wrapped = new EntityWrapper($test, $this->em);
+
+        $this->assertEquals('1 2', $wrapped->getIdentifier(false, true));
+        $this->assertEquals('test', $wrapped->getPropertyValue('title'));
+    }
+
+    public function testCompositeRelationProxy()
+    {
+        $this->em->clear();
+        $art1 = $this->em->getReference(self::ARTICLE, ['id' => 1]);
+        $test = $this->em->getReference(self::COMPOSITE_RELATION, ['article' => $art1->getId(), 'status' => 2]);
+        $this->assertInstanceOf('Doctrine\\ORM\\Proxy\\Proxy', $test);
+        $wrapped = new EntityWrapper($test, $this->em);
+
+        $this->assertEquals('1 2', $wrapped->getIdentifier(false, true));
+        $this->assertEquals('test', $wrapped->getPropertyValue('title'));
+    }
+
     public function testSomeFunctions()
     {
         $test = new Article();
@@ -92,14 +159,22 @@ class EntityWrapperTest extends BaseTestCaseORM
     {
         return [
             self::ARTICLE,
+            self::COMPOSITE,
+            self::COMPOSITE_RELATION,
         ];
     }
 
     private function populate()
     {
-        $test = new Article();
-        $test->setTitle('test');
-        $this->em->persist($test);
+        $article = new Article();
+        $article->setTitle('test');
+        $this->em->persist($article);
+        $composite = new Composite(1, 2);
+        $composite->setTitle('test');
+        $this->em->persist($composite);
+        $compositeRelation = new CompositeRelation($article, 2);
+        $compositeRelation->setTitle('test');
+        $this->em->persist($compositeRelation);
         $this->em->flush();
     }
 }

--- a/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/Composite.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wrapper\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Composite
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $one;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $two;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    public function __construct($one, $two)
+    {
+        $this->one = $one;
+        $this->two = $two;
+    }
+
+    public function getOne()
+    {
+        return $this->one;
+    }
+
+    public function getTwo()
+    {
+        return $this->two;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
+++ b/tests/Gedmo/Wrapper/Fixture/Entity/CompositeRelation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wrapper\Fixture\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class CompositeRelation
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Wrapper\Fixture\Entity\Article")
+     */
+    private $article;
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $status;
+
+    /**
+     * @ORM\Column(length=128)
+     */
+    private $title;
+
+    public function __construct(Article $articleOne, $status)
+    {
+        $this->article = $articleOne;
+        $this->status = $status;
+    }
+
+    public function getArticle()
+    {
+        return $this->article;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}


### PR DESCRIPTION
Composite identifiers with foreign entities availaible for ORM > 2.6 due to earlier version not handling identifiers for newly inserted foreign objects