### PR TITLE
[TREE][Materialized] Fixed path not correctly insert entity ID when TreeSource is type int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes below marked ⚠️ may also be breaking, if you have extended DoctrineE
 ### Tree
 #### Fixed
 - The value of path source property is cast to string type for Materialized Path Tree strategy (#2061)
+- Fixed Materialized path not appending entity ID if TreeSource is of type integer and setting appendId is true.
 
 ### SoftDeleteable
 #### Changed

--- a/src/Tree/Strategy/AbstractMaterializedPath.php
+++ b/src/Tree/Strategy/AbstractMaterializedPath.php
@@ -101,7 +101,10 @@ abstract class AbstractMaterializedPath implements Strategy
         $config = $this->listener->getConfiguration($om, $meta->name);
         $fieldMapping = $meta->getFieldMapping($config['path_source']);
 
-        if ($meta->isIdentifier($config['path_source']) || 'string' === $fieldMapping['type']) {
+        if (true === $config['path_append_id']
+            || $meta->isIdentifier($config['path_source'])
+            || 'string' === $fieldMapping['type']
+        ) {
             $this->scheduledForPathProcess[spl_object_hash($node)] = $node;
         } else {
             $this->updateNode($om, $node, $ea);

--- a/tests/Gedmo/Tree/Fixture/Document/CategoryWithAppendIdOnIntegerSource.php
+++ b/tests/Gedmo/Tree/Fixture/Document/CategoryWithAppendIdOnIntegerSource.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tree\Fixture\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MONGO;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @MONGO\Document(repositoryClass="Gedmo\Tree\Document\MongoDB\Repository\MaterializedPathRepository")
+ * @Gedmo\Tree(type="materializedPath")
+ */
+class CategoryWithAppendIdOnIntegerSource
+{
+    /**
+     * @MONGO\Id
+     */
+    private $id;
+
+    /**
+     * @MONGO\Field(type="string")
+     */
+    private $title;
+
+    /**
+     * @MONGO\Field(type="int")
+     * @Gedmo\TreePathSource
+     */
+    private $integerSort;
+
+    /**
+     * @MONGO\Field(type="string")
+     * @Gedmo\TreePath(appendId=true, separator="|")
+     */
+    private $path;
+
+    /**
+     * @Gedmo\TreeParent
+     * @MONGO\ReferenceOne(targetDocument="Tree\Fixture\Document\CategoryWithAppendIdOnIntegerSource")
+     */
+    private $parent;
+
+    /**
+     * @Gedmo\TreeLevel
+     * @MONGO\Field(type="int")
+     */
+    private $level;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setIntegerSort(int $sort)
+    {
+        $this->integerSort = $sort;
+    }
+
+    public function getIntegerSort()
+    {
+        return $this->integerSort;
+    }
+
+    public function setParent(CategoryWithAppendIdOnIntegerSource $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+}

--- a/tests/Gedmo/Tree/Fixture/MPCategoryWithAppendIdOnIntegerSource.php
+++ b/tests/Gedmo/Tree/Fixture/MPCategoryWithAppendIdOnIntegerSource.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tree\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\MaterializedPathRepository")
+ * @Gedmo\Tree(type="materializedPath")
+ */
+class MPCategoryWithAppendIdOnIntegerSource
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Gedmo\TreePath(appendId=true)
+     * @ORM\Column(name="path", type="string", length=3000, nullable=true)
+     */
+    private $path;
+
+    /**
+     * @Gedmo\TreePathHash
+     * @ORM\Column(name="pathhash", type="string", length=32, nullable=true)
+     */
+    private $pathHash;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\TreePathSource
+     * @ORM\Column(name="integer_sort", type="integer")
+     */
+    private $integerSort;
+
+    /**
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="MPCategoryWithAppendIdOnIntegerSource", inversedBy="children")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $parentId;
+
+    /**
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer", nullable=true)
+     */
+    private $level;
+
+    /**
+     * @Gedmo\TreeRoot
+     * @ORM\Column(name="tree_root_value", type="string", nullable=true)
+     */
+    private $treeRootValue;
+
+    /**
+     * @ORM\OneToMany(targetEntity="MPCategoryWithAppendIdOnIntegerSource", mappedBy="parent")
+     */
+    private $children;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Article", mappedBy="category")
+     */
+    private $comments;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setIntegerSort(int $sort)
+    {
+        $this->integerSort = $sort;
+    }
+
+    public function getIntegerSort()
+    {
+        return $this->integerSort;
+    }
+
+    public function setParent(MPCategoryWithAppendIdOnIntegerSource $parent = null)
+    {
+        $this->parentId = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parentId;
+    }
+
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    public function getTreeRootValue()
+    {
+        return $this->treeRootValue;
+    }
+
+    public function getPathHash()
+    {
+        return $this->pathHash;
+    }
+}

--- a/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathODMMongoDBTest.php
@@ -219,7 +219,7 @@ class MaterializedPathODMMongoDBTest extends BaseTestCaseMongoODM
 
     public function createCategoryWithAppendIdAndSourceAsTypeInteger()
     {
-        $class  = self::CATEGORY_APPENDID;
+        $class = self::CATEGORY_APPENDID;
 
         return new $class();
     }

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -18,6 +18,7 @@ use Tool\BaseTestCaseORM;
 class MaterializedPathORMTest extends BaseTestCaseORM
 {
     const CATEGORY = 'Tree\\Fixture\\MPCategory';
+    const CATEGORY_APPENDID = 'Tree\\Fixture\\MPCategoryWithAppendIdOnIntegerSource';
 
     protected $config;
     protected $listener;
@@ -132,9 +133,117 @@ class MaterializedPathORMTest extends BaseTestCaseORM
         $this->em->flush();
     }
 
+    /**
+     * @test
+     */
+    public function useAppendIdWhenTreeSourceIsOfTypeInteger()
+    {
+        $meta = $this->em->getClassMetadata(self::CATEGORY_APPENDID);
+        $this->config = $this->listener->getConfiguration($this->em, $meta->name);
+
+        // Insert
+        $category = $this->createCategoryWithAppendIdAndTreeSourceAsInteger();
+        $category->setIntegerSort(10);
+        $category->setTitle('1');
+        $category2 = $this->createCategoryWithAppendIdAndTreeSourceAsInteger();
+        $category2->setIntegerSort(20);
+        $category2->setTitle('2');
+        $category3 = $this->createCategoryWithAppendIdAndTreeSourceAsInteger();
+        $category3->setIntegerSort(30);
+        $category3->setTitle('3');
+        $category4 = $this->createCategoryWithAppendIdAndTreeSourceAsInteger();
+        $category4->setIntegerSort(40);
+        $category4->setTitle('4');
+
+        $category2->setParent($category);
+        $category3->setParent($category2);
+
+        $this->em->persist($category4);
+        $this->em->persist($category3);
+        $this->em->persist($category2);
+        $this->em->persist($category);
+        $this->em->flush();
+
+        $this->em->refresh($category);
+        $this->em->refresh($category2);
+        $this->em->refresh($category3);
+        $this->em->refresh($category4);
+
+        $this->assertEquals($this->generatePath(['10' => $category->getId()]), $category->getPath());
+
+        $this->assertEquals(
+            $this->generatePath(['10' => $category->getId(), '20' => $category2->getId()]),
+            $category2->getPath()
+        );
+        $this->assertEquals(
+            $this->generatePath([
+                '10' => $category->getId(),
+                '20' => $category2->getId(),
+                '30' => $category3->getId()
+            ]),
+            $category3->getPath()
+        );
+
+        $this->assertEquals($this->generatePath(['40' => $category4->getId()]), $category4->getPath());
+        $this->assertEquals(1, $category->getLevel());
+        $this->assertEquals(2, $category2->getLevel());
+        $this->assertEquals(3, $category3->getLevel());
+        $this->assertEquals(1, $category4->getLevel());
+
+        $this->assertEquals('10-4', $category->getTreeRootValue());
+        $this->assertEquals('10-4', $category2->getTreeRootValue());
+        $this->assertEquals('10-4', $category3->getTreeRootValue());
+        $this->assertEquals('40-1', $category4->getTreeRootValue());
+
+        // Update
+        $category2->setParent(null);
+
+        $this->em->persist($category2);
+        $this->em->flush();
+
+        $this->em->refresh($category);
+        $this->em->refresh($category2);
+        $this->em->refresh($category3);
+
+        $this->assertEquals($this->generatePath(['10' => $category->getId()]), $category->getPath());
+        $this->assertEquals($this->generatePath(['20' => $category2->getId()]), $category2->getPath());
+        $this->assertEquals($this->generatePath(['20' => $category2->getId(), '30' => $category3->getId()]),
+            $category3->getPath());
+        $this->assertEquals(1, $category->getLevel());
+        $this->assertEquals(1, $category2->getLevel());
+        $this->assertEquals(2, $category3->getLevel());
+        $this->assertEquals(1, $category4->getLevel());
+
+        $this->assertEquals('10-4', $category->getTreeRootValue());
+        $this->assertEquals('20-3', $category2->getTreeRootValue());
+        $this->assertEquals('20-3', $category3->getTreeRootValue());
+        $this->assertEquals('40-1', $category4->getTreeRootValue());
+
+        // Remove
+        $this->em->remove($category);
+        $this->em->remove($category2);
+        $this->em->flush();
+
+        $result = $this->em->createQueryBuilder()->select('c')->from(self::CATEGORY_APPENDID, 'c')->getQuery()->execute();
+
+        $firstResult = $result[0];
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('4', $firstResult->getTitle());
+        $this->assertEquals(1, $firstResult->getLevel());
+        $this->assertEquals('40-1', $firstResult->getTreeRootValue());
+    }
+
     public function createCategory()
     {
         $class = self::CATEGORY;
+
+        return new $class();
+    }
+
+    public function createCategoryWithAppendIdAndTreeSourceAsInteger()
+    {
+        $class = self::CATEGORY_APPENDID;
 
         return new $class();
     }
@@ -143,6 +252,7 @@ class MaterializedPathORMTest extends BaseTestCaseORM
     {
         return [
             self::CATEGORY,
+            self::CATEGORY_APPENDID,
         ];
     }
 

--- a/tests/Gedmo/Tree/MaterializedPathORMTest.php
+++ b/tests/Gedmo/Tree/MaterializedPathORMTest.php
@@ -179,7 +179,7 @@ class MaterializedPathORMTest extends BaseTestCaseORM
             $this->generatePath([
                 '10' => $category->getId(),
                 '20' => $category2->getId(),
-                '30' => $category3->getId()
+                '30' => $category3->getId(),
             ]),
             $category3->getPath()
         );


### PR DESCRIPTION
Fixed a bug where the entity ID was not correctly inserted in path if the TreePathSource is of type integer and appendId is true.
See example:
```php
    /**
     * @Gedmo\TreePath(appendId=true)
     * @ORM\Column(name="path", type="string", length=3000, nullable=true)
     */
    private $path;

    /**
     * @Gedmo\TreePathSource
     * @ORM\Column(name="integer_sort", type="integer")
     */
    private $integerSort;
```