### PR TITLE
fix custom EventArgs error

### DIFF
--- a/lib/Gedmo/Mapping/MappedEventSubscriber.php
+++ b/lib/Gedmo/Mapping/MappedEventSubscriber.php
@@ -88,6 +88,9 @@ abstract class MappedEventSubscriber implements EventSubscriber
     protected function getEventAdapter(EventArgs $args)
     {
         $class = get_class($args);
+        if (0 === preg_match('@Doctrine\\\([^\\\]+)@', $class)) {
+            $class = get_parent_class($args);
+        }
         if (preg_match('@Doctrine\\\([^\\\]+)@', $class, $m) && in_array($m[1], array('ODM', 'ORM'))) {
             if (!isset($this->adapters[$m[1]])) {
                 $adapterClass = $this->getNamespace().'\\Mapping\\Event\\Adapter\\'.$m[1];


### PR DESCRIPTION
I write my own ModifyClassMetadataArgs class extends LoadClassMetadataArgs, and pass this to my doctrine Listener. 
Then Gedmo\Mapping\MappedEventSubscriber::getEventAdapter(EventArgs $args) throw Exception. Use $args parent class name will fix this exception.