### PR TITLE
[translatable] Update TranslationRepository.php

### DIFF
--- a/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
+++ b/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php
@@ -3,7 +3,7 @@
 namespace Gedmo\Translatable\Document\Repository;
 
 use Gedmo\Translatable\TranslatableListener;
-use Doctrine\ODM\MongoDB\DocumentRepository;
+use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;


### PR DESCRIPTION
Symfony\Component\ErrorHandler\Error\ClassNotFoundError^ {#2569
  #message: """
    Attempted to load class "DocumentRepository" from namespace "Doctrine\ODM\MongoDB".\n
    Did you forget a "use" statement for "Doctrine\ODM\MongoDB\Repository\DocumentRepository"?
    """
  #code: 0
  #file: "./vendor/gedmo/doctrine-extensions/lib/Gedmo/Translatable/Document/Repository/TranslationRepository.php"
  #line: 21