### PR TITLE
[Tree] left position should respect root in another table

### DIFF
--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -400,14 +400,16 @@ class Nested implements Strategy
             $newRoot = $parentRoot;
         } elseif (!isset($config['root']) ||
             ($meta->isSingleValuedAssociation($config['root']) && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
-            if (!isset($this->treeEdges[$meta->name])) {
-                $this->treeEdges[$meta->name] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
+            $newRootHash = is_object($newRoot) ? spl_object_hash($newRoot) : $newRoot;
+
+            if (!isset($this->treeEdges[$meta->name][$newRootHash])) {
+                $this->treeEdges[$meta->name][$newRootHash] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
             }
 
             $level = 0;
             $parentLeft = 0;
-            $parentRight = $this->treeEdges[$meta->name];
-            $this->treeEdges[$meta->name] += 2;
+            $parentRight = $this->treeEdges[$meta->name][$newRootHash];
+            $this->treeEdges[$meta->name][$newRootHash] += 2;
 
             switch ($position) {
                 case self::PREV_SIBLING:

--- a/src/Tree/Strategy/ORM/Nested.php
+++ b/src/Tree/Strategy/ORM/Nested.php
@@ -398,9 +398,13 @@ class Nested implements Strategy
                 $wrapped->setPropertyValue($config['right'], $right);
             }
             $newRoot = $parentRoot;
+            $newRootHash = $this->calculateNewRootHash($newRoot);
+            if (isset($this->treeEdges[$meta->name][$newRootHash])) {
+                $this->treeEdges[$meta->name][$newRootHash] += 2;
+            }
         } elseif (!isset($config['root']) ||
             ($meta->isSingleValuedAssociation($config['root']) && ($newRoot = $meta->getFieldValue($node, $config['root'])))) {
-            $newRootHash = is_object($newRoot) ? spl_object_hash($newRoot) : $newRoot;
+            $newRootHash = $this->calculateNewRootHash($newRoot);
 
             if (!isset($this->treeEdges[$meta->name][$newRootHash])) {
                 $this->treeEdges[$meta->name][$newRootHash] = $this->max($em, $config['useObjectClass'], $newRoot) + 1;
@@ -709,5 +713,15 @@ class Nested implements Strategy
                 }
             }
         }
+    }
+
+    /**
+     * @param object|mixed $newRoot
+     *
+     * @return string|mixed
+     */
+    protected function calculateNewRootHash($newRoot)
+    {
+        return is_object($newRoot) ? spl_object_hash($newRoot) : $newRoot;
     }
 }

--- a/tests/Gedmo/Tree/Fixture/RootAssociationSubCategory.php
+++ b/tests/Gedmo/Tree/Fixture/RootAssociationSubCategory.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tree\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+/**
+ * @ORM\Entity(repositoryClass="Gedmo\Tree\Entity\Repository\NestedTreeRepository")
+ * @Gedmo\Tree(type="nested")
+ */
+class RootAssociationSubCategory
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="title", type="string", length=64)
+     */
+    private $title;
+
+    /**
+     * @Gedmo\TreeLeft
+     * @ORM\Column(name="lft", type="integer")
+     */
+    private $lft;
+
+    /**
+     * @Gedmo\TreeRight
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    private $rgt;
+
+    /**
+     * @Gedmo\TreeParent
+     * @ORM\ManyToOne(targetEntity="RootAssociationSubCategory", inversedBy="children")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $parent;
+
+    /**
+     * @Gedmo\TreeRoot
+     * @ORM\ManyToOne(targetEntity="RootAssociationCategory")
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     * })
+     */
+    private $root;
+
+    /**
+     * @Gedmo\TreeLevel
+     * @ORM\Column(name="lvl", type="integer")
+     */
+    private $level;
+
+    /**
+     * @ORM\OneToMany(targetEntity="RootAssociationSubCategory", mappedBy="parent")
+     */
+    private $children;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setParent(RootAssociationSubCategory $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function getRoot()
+    {
+        return $this->root;
+    }
+
+    public function setRoot(RootAssociationCategory $root): void
+    {
+        $this->root = $root;
+    }
+
+    public function getLeft()
+    {
+        return $this->lft;
+    }
+
+    public function getRight()
+    {
+        return $this->rgt;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+}

--- a/tests/Gedmo/Tree/NestedTreeRootAssociationSubTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootAssociationSubTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Gedmo\Tree;
+
+use Doctrine\Common\EventManager;
+use Tool\BaseTestCaseORM;
+use Tree\Fixture\RootAssociationCategory;
+use Tree\Fixture\RootAssociationSubCategory;
+
+/**
+ * These are tests for Tree behavior
+ *
+ * @author Valery Vargin <VDVUGaD@gmail.com>
+ *
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class NestedTreeRootAssociationSubTest extends BaseTestCaseORM
+{
+    public const CATEGORY = RootAssociationCategory::class;
+    public const SUB_CATEGORY = RootAssociationSubCategory::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $evm = new EventManager();
+        $evm->addEventSubscriber(new TreeListener());
+
+        $this->getMockSqliteEntityManager($evm);
+        $this->populate();
+    }
+
+    public function testRootEntity(): void
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+        $subRepo = $this->em->getRepository(self::SUB_CATEGORY);
+
+        // roots from another table
+        /** @var \Tree\Fixture\RootAssociationCategory $food */
+        $food = $repo->findOneBy(['title' => 'Food']);
+        /** @var \Tree\Fixture\RootAssociationCategory $sports */
+        $sports = $repo->findOneBy(['title' => 'Sports']);
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $fruits */
+        $fruits = $subRepo->findOneBy(['title' => 'Fruits']);
+        $this->assertEquals($food->getId(), $fruits->getRoot()->getId());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $apples */
+        $apples = $subRepo->findOneBy(['title' => 'Apples']);
+        $this->assertEquals($food->getId(), $apples->getRoot()->getId(), 'Subcategory child should respect parent root');
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $summer */
+        $summer = $subRepo->findOneBy(['title' => 'Summer']);
+        $this->assertEquals($sports->getId(), $summer->getRoot()->getId());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $basketball */
+        $basketball = $subRepo->findOneBy(['title' => 'Basketball']);
+        $this->assertEquals($sports->getId(), $basketball->getRoot()->getId());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $football */
+        $football = $subRepo->findOneBy(['title' => 'Football']);
+        $this->assertEquals($sports->getId(), $football->getRoot()->getId());
+    }
+
+    public function testPositions(): void
+    {
+        $repo = $this->em->getRepository(self::SUB_CATEGORY);
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $fruits */
+        $fruits = $repo->findOneBy(['title' => 'Fruits']);
+        $this->assertEquals(1, $fruits->getLeft());
+        $this->assertEquals(4, $fruits->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $apples */
+        $apples = $repo->findOneBy(['title' => 'Apples']);
+        $this->assertEquals(2, $apples->getLeft());
+        $this->assertEquals(3, $apples->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $summer */
+        $summer = $repo->findOneBy(['title' => 'Summer']);
+        $this->assertEquals(1, $summer->getLeft(), 'Another root, so should started from begin');
+        $this->assertEquals(6, $summer->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $basketball */
+        $basketball = $repo->findOneBy(['title' => 'Basketball']);
+        $this->assertEquals(2, $basketball->getLeft());
+        $this->assertEquals(3, $basketball->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationSubCategory $football */
+        $football = $repo->findOneBy(['title' => 'Football']);
+        $this->assertEquals(4, $football->getLeft());
+        $this->assertEquals(5, $football->getRight());
+    }
+
+    protected function getUsedEntityFixtures(): array
+    {
+        return [
+            self::CATEGORY,
+            self::SUB_CATEGORY,
+        ];
+    }
+
+    /**
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\Persistence\Mapping\MappingException
+     */
+    private function populate(): void
+    {
+        // Base categories stores in one table, sub categories - in another tables
+        $food = new RootAssociationCategory();
+        $food->setTitle('Food');
+
+        // left 1 right 4
+        $fruits = new RootAssociationSubCategory();
+        $fruits->setTitle('Fruits');
+        $fruits->setRoot($food);
+
+        // left 2 right 3
+        $apples = new RootAssociationSubCategory();
+        $apples->setTitle('Apples');
+        $apples->setParent($fruits);
+
+        // Base category for sports
+        $sports = new RootAssociationCategory();
+        $sports->setTitle('Sports');
+
+        // left 1 right 6
+        $winter = new RootAssociationSubCategory();
+        $winter->setTitle('Summer');
+        $winter->setRoot($sports);
+
+        // left 2 right 3
+        $basketball = new RootAssociationSubCategory();
+        $basketball->setTitle('Basketball');
+        $basketball->setParent($winter);
+
+        // left 4 right 5
+        $football = new RootAssociationSubCategory();
+        $football->setTitle('Football');
+        $football->setParent($winter);
+
+        $this->em->persist($food);
+        $this->em->persist($sports);
+        $this->em->persist($fruits);
+        $this->em->persist($apples);
+        $this->em->persist($winter);
+        $this->em->persist($basketball);
+        $this->em->persist($football);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}

--- a/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
+++ b/tests/Gedmo/Tree/NestedTreeRootAssociationTest.php
@@ -55,6 +55,43 @@ class NestedTreeRootAssociationTest extends BaseTestCaseORM
         $this->assertEquals($sports->getId(), $sports->getRoot()->getId());
     }
 
+    public function testPositions(): void
+    {
+        $repo = $this->em->getRepository(self::CATEGORY);
+
+        // Foods
+        /** @var \Tree\Fixture\RootAssociationCategory $food */
+        $food = $repo->findOneBy(['title' => 'Food']);
+        $this->assertEquals(1, $food->getLeft());
+        $this->assertEquals(10, $food->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationCategory $fruits */
+        $fruits = $repo->findOneBy(['title' => 'Fruits']);
+        $this->assertEquals(2, $fruits->getLeft());
+        $this->assertEquals(3, $fruits->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationCategory $vegetables */
+        $vegetables = $repo->findOneBy(['title' => 'Vegetables']);
+        $this->assertEquals(4, $vegetables->getLeft());
+        $this->assertEquals(9, $vegetables->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationCategory $carrots */
+        $carrots = $repo->findOneBy(['title' => 'Carrots']);
+        $this->assertEquals(5, $carrots->getLeft());
+        $this->assertEquals(6, $carrots->getRight());
+
+        /** @var \Tree\Fixture\RootAssociationCategory $potatoes */
+        $potatoes = $repo->findOneBy(['title' => 'Potatoes']);
+        $this->assertEquals(7, $potatoes->getLeft());
+        $this->assertEquals(8, $potatoes->getRight());
+
+        // Sports
+        /** @var \Tree\Fixture\RootAssociationCategory $sports */
+        $sports = $repo->findOneBy(['title' => 'Sports']);
+        $this->assertEquals(1, $sports->getLeft(), 'Another root, so should started from begin');
+        $this->assertEquals(2, $sports->getRight());
+    }
+
     protected function getUsedEntityFixtures()
     {
         return [
@@ -64,24 +101,30 @@ class NestedTreeRootAssociationTest extends BaseTestCaseORM
 
     private function populate()
     {
+        // left 1 right 10
         $root = new RootAssociationCategory();
         $root->setTitle('Food');
 
+        // left 1 right 2
         $root2 = new RootAssociationCategory();
         $root2->setTitle('Sports');
 
+        // left 2 right 3
         $child = new RootAssociationCategory();
         $child->setTitle('Fruits');
         $child->setParent($root);
 
+        // left 4 right 9
         $child2 = new RootAssociationCategory();
         $child2->setTitle('Vegetables');
         $child2->setParent($root);
 
+        // left 5 right 6
         $childsChild = new RootAssociationCategory();
         $childsChild->setTitle('Carrots');
         $childsChild->setParent($child2);
 
+        // left 7 right 8
         $potatoes = new RootAssociationCategory();
         $potatoes->setTitle('Potatoes');
         $potatoes->setParent($child2);


### PR DESCRIPTION
If my category has a root in another table, the Nested Strategy should start the left position for each root separately.

Test case you can see in NestedTreeRootAssociationSubTest
```text
Food <- stored in another table
| - Fruits should has [1, 4]
    | - Apples should has [2, 3]
Sports <- stored in another table
| - Summery should has [1, 6]
    | - Basketball should has [2, 3]
    | - Football should has [4, 5]
```

Current behaviour is
```text
Food <- stored in another table
| - Fruits has [1, 4]
    | - Apples has [2, 3]
Sports <- stored in another table
| - Summery has [5, 10]
    | - Basketball has [6, 7]
    | - Football has [8, 9]
```