### PR TITLE
Document the SoftDeleteable::$deletedAt as nullable property

### DIFF
--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteable.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteable.php
@@ -11,7 +11,7 @@ namespace Gedmo\SoftDeleteable\Traits;
 trait SoftDeleteable
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $deletedAt;
 
@@ -32,7 +32,7 @@ trait SoftDeleteable
     /**
      * Returns deletedAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {

--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableDocument.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableDocument.php
@@ -13,7 +13,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 trait SoftDeleteableDocument
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @ODM\Field(type="date")
      */
     protected $deletedAt;
@@ -35,7 +35,7 @@ trait SoftDeleteableDocument
     /**
      * Returns deletedAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {

--- a/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
+++ b/lib/Gedmo/SoftDeleteable/Traits/SoftDeleteableEntity.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 trait SoftDeleteableEntity
 {
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      * @ORM\Column(type="datetime", nullable=true)
      */
     protected $deletedAt;
@@ -35,7 +35,7 @@ trait SoftDeleteableEntity
     /**
      * Returns deletedAt.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDeletedAt()
     {


### PR DESCRIPTION
We have some PhpStan issues when using the traits provided by this package.

The issue comes from the fact that the property `deletedAt` will not always be hydrated and can be null