### PR TITLE
Fix Metadata Cache

### DIFF
--- a/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
+++ b/lib/Gedmo/Mapping/ExtensionMetadataFactory.php
@@ -102,7 +102,7 @@ class ExtensionMetadataFactory
         // caching empty metadata will prevent re-parsing non-existent annotations
         $cacheId = self::getCacheId($meta->name, $this->extensionNamespace);
         if ($cacheDriver = $cmf->getCacheDriver()) {
-            $cacheDriver->save($cacheId, $config, null);
+            $cacheDriver->save($cacheId, $config);
         }
 
         return $config;


### PR DESCRIPTION
The old code (from past 10 years) put third parametr to `save()` as null which prevent symfony from caching it.. Removing it it use 0 (as default parametr from cache providers) which act like infinity.

Without it, my memcache each time regenerates this file..