### PR TITLE
Migrated zend to laminas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ a release.
 - Source files moved from `/lib/Gedmo` to `/src`
 - Added compatibility for `doctrine/common` 3.0 and `doctrine/persistence` 2.0
 - All string column type annotations changed to 191 character length (#1941)
+- Removed support for `\Zend_date` date format [#2163](https://github.com/Atlantic18/DoctrineExtensions/pull/2163)
+- Renamed `Zend Framework` to `Laminas` [#2163](https://github.com/Atlantic18/DoctrineExtensions/pull/2163)
 
 Changes below marked ⚠️ may also be breaking, if you have extended DoctrineExtensions.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For the current old-but-stable version, see the [v2.4.x branch](https://github.c
 * [Symfony 2](/doc/symfony2.md)
 * [Symfony 4](/doc/symfony4.md)
 * [Laravel 5](https://www.laraveldoctrine.org/docs/1.3/extensions)
-* [Zend Framework 2](/doc/zendframework2.md)
+* [Laminas](/doc/laminas.md)
 
 ### Upgrading
 

--- a/doc/laminas.md
+++ b/doc/laminas.md
@@ -1,22 +1,10 @@
 ## Using Gedmo Doctrine Extensions in Zend Framework 2
 
-Assuming you are familiar with [DoctrineModule](https://github.com/doctrine/DoctrineModule) (if not, you should definitely start there!), integrating Doctrine Extensions with Zend Framework 2 application is super-easy.
+Assuming you are familiar with [DoctrineModule](https://github.com/doctrine/DoctrineModule) (if not, you should definitely start there!), integrating Doctrine Extensions with Laminas application is super-easy.
 
 ### Composer
 
-Add DoctrineModule, DoctrineORMModule and DoctrineExtensions to composer.json file:
-
-```json
-{
-    "require": {
-        "php": ">=5.3.3",
-        "zendframework/zendframework": "2.1.*",
-        "doctrine/doctrine-module": "0.*",
-        "doctrine/doctrine-orm-module": "0.*",
-        "gedmo/doctrine-extensions": "2.3.*",
-    }
-}
-```
+Add `doctrine/doctrine-module`, `doctrine/doctrine-orm-module` and `gedmo/doctrine-extensions` to composer.json file
 
 Then run `composer.phar update`.
 
@@ -56,7 +44,7 @@ return array(
 );
 ```
 
-That's it! From now on you can use Gedmo annotations, just as it is described in [documentation](https://github.com/mtymek/DoctrineExtensions/blob/master/doc/annotations.md).
+That's it! From now on you can use Gedmo annotations, just as it is described in [documentation](https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/annotations.md).
 
 #### Note: You may need to provide additional settings for some of the available listeners.
 

--- a/doc/laminas.md
+++ b/doc/laminas.md
@@ -1,10 +1,10 @@
-## Using Gedmo Doctrine Extensions in Zend Framework 2
+## Using Gedmo Doctrine Extensions in Laminas
 
 Assuming you are familiar with [DoctrineModule](https://github.com/doctrine/DoctrineModule) (if not, you should definitely start there!), integrating Doctrine Extensions with Laminas application is super-easy.
 
 ### Composer
 
-Add `doctrine/doctrine-module`, `doctrine/doctrine-orm-module` and `gedmo/doctrine-extensions` to composer.json file
+Add `doctrine/doctrine-module`, `doctrine/doctrine-orm-module` or `doctrine/doctrine-mongo-odm-module` to composer.json file
 
 Then run `composer.phar update`.
 

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ODM.php
@@ -24,9 +24,6 @@ final class ODM extends BaseAdapterODM implements SoftDeleteableAdapter
         if (isset($mapping['type']) && 'timestamp' === $mapping['type']) {
             return time();
         }
-        if (isset($mapping['type']) && 'zenddate' == $mapping['type']) {
-            return new \Zend_Date();
-        }
         if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
             return new \DateTimeImmutable();
         }

--- a/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
+++ b/src/SoftDeleteable/Mapping/Event/Adapter/ORM.php
@@ -23,9 +23,6 @@ final class ORM extends BaseAdapterORM implements SoftDeleteableAdapter
         if (isset($mapping['type']) && 'integer' === $mapping['type']) {
             return time();
         }
-        if (isset($mapping['type']) && 'zenddate' == $mapping['type']) {
-            return new \Zend_Date();
-        }
         if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
             return new \DateTimeImmutable();
         }

--- a/src/SoftDeleteable/Mapping/Validator.php
+++ b/src/SoftDeleteable/Mapping/Validator.php
@@ -29,7 +29,6 @@ class Validator
         'datetimetz',
         'datetimetz_immutable',
         'timestamp',
-        'zenddate',
     ];
 
     public static function validateField(ClassMetadata $meta, $field)

--- a/src/Timestampable/Mapping/Driver/Annotation.php
+++ b/src/Timestampable/Mapping/Driver/Annotation.php
@@ -36,7 +36,6 @@ class Annotation extends AbstractAnnotationDriver
         'datetimetz',
         'datetimetz_immutable',
         'timestamp',
-        'zenddate',
         'vardatetime',
         'integer',
     ];

--- a/src/Timestampable/Mapping/Driver/Xml.php
+++ b/src/Timestampable/Mapping/Driver/Xml.php
@@ -32,7 +32,6 @@ class Xml extends BaseXml
         'datetimetz',
         'datetimetz_immutable',
         'timestamp',
-        'zenddate',
         'vardatetime',
         'integer',
     ];

--- a/src/Timestampable/Mapping/Driver/Yaml.php
+++ b/src/Timestampable/Mapping/Driver/Yaml.php
@@ -39,7 +39,6 @@ class Yaml extends File implements Driver
         'datetimetz',
         'datetimetz_immutable',
         'timestamp',
-        'zenddate',
         'vardatetime',
         'integer',
     ];

--- a/src/Timestampable/Mapping/Event/Adapter/ODM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ODM.php
@@ -23,9 +23,6 @@ final class ODM extends BaseAdapterODM implements TimestampableAdapter
         if (isset($mapping['type']) && 'timestamp' === $mapping['type']) {
             return time();
         }
-        if (isset($mapping['type']) && 'zenddate' == $mapping['type']) {
-            return new \Zend_Date();
-        }
         if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
             return new \DateTimeImmutable();
         }

--- a/src/Timestampable/Mapping/Event/Adapter/ORM.php
+++ b/src/Timestampable/Mapping/Event/Adapter/ORM.php
@@ -23,9 +23,6 @@ final class ORM extends BaseAdapterORM implements TimestampableAdapter
         if (isset($mapping['type']) && 'integer' === $mapping['type']) {
             return time();
         }
-        if (isset($mapping['type']) && 'zenddate' == $mapping['type']) {
-            return new \Zend_Date();
-        }
         if (isset($mapping['type']) && in_array($mapping['type'], ['date_immutable', 'time_immutable', 'datetime_immutable', 'datetimetz_immutable'], true)) {
             return new \DateTimeImmutable();
         }


### PR DESCRIPTION
Renamed Zend Framework to Laminas and removed `zenddate` date format because `\Zend_Date` is no longer supported for many years