### PR TITLE
Fix wrong usage of Comparable interface & misleading docs

### DIFF
--- a/doc/sortable.md
+++ b/doc/sortable.md
@@ -304,6 +304,8 @@ $item2->setPosition(-1);
 Sortable works by comparing objects in the same group to see how they should be positioned. From time to time you may want to customize the way these
 objects are compared by simply implementing the Doctrine\Common\Comparable interface
 
+**Warning** the `Comparable` interface should be implemented on the group object
+
 ``` php
 <?php
 namespace Entity;
@@ -311,17 +313,12 @@ namespace Entity;
 use Doctrine\Common\Comparable;
 
 /**
- * @ORM\Table(name="items")
- * @ORM\Entity(repositoryClass="Gedmo\Sortable\Entity\Repository\SortableRepository")
+ * @ORM\Table(name="category")
  */
-class Item implements Comparable
+class Category implements Comparable
 {
     public function compareTo($other)
     {
-        // return 1 if this object is considered greater than the compare value
-
-        // return -1 if this object is considered less than the compare value
-
         // return 0 if this object is considered equal to the compare value
     }
 }

--- a/lib/Gedmo/Sortable/SortableListener.php
+++ b/lib/Gedmo/Sortable/SortableListener.php
@@ -465,9 +465,9 @@ class SortableListener extends MappedEventSubscriber
                                 // If the object implements Comparable interface we can use its compareTo method
                                 // Otherwise we fallback to normal object comparison
                                 if ($gr instanceof Comparable) {
-                                    $matches = $gr->compareTo($value);
+                                    $matches = 0 === ($gr->compareTo($value));
                                 } else {
-                                    $matches = $gr == $value;
+                                    $matches = $gr === $value;
                                 }
                             } else {
                                 $matches = $gr === $value;


### PR DESCRIPTION
Hi, 

When using a deeply nested object as the sortable group, it is still very common to have the following error: 

> Nesting level too deep - recursive dependency?

Actually, there is a wrong usage of the `Doctrine\Common\Comparable` interface introduced in 4017af65a0a5cca6c6646cda728c92e925cfdabe, & a misleading documentation. 

1/ The documentation suggests to implement the interface on the item, while in the code it is actually used **on the group**. 

2/ The error happens, because when the group is an object, did not exist before and **DOES NOT** implement the `Comparable` interface, the comparison is done with `==` ([at this line](https://github.com/Atlantic18/DoctrineExtensions/blob/2cd7277ae49ec8c2640b247e5af4e36c58e78f22/lib/Gedmo/Sortable/SortableListener.php#L470)). When objects are deeply nested, `==` will compare all properties of the object recursively. 

See the piece of code below with comments: 

```php
while ($matches && ($group = key($relocation['groups']))) {
    $gr = $meta->getReflectionProperty($group)->getValue($object);
    if (null === $value) {
        $matches = $gr === null;
    } elseif (is_object($gr) && is_object($value) && $gr !== $value) {
        if ($gr instanceof Comparable) {
            // First problem
            // compareTo should return 0 if objects are equal
            // but $matches is actually as boolean
            $matches = $gr->compareTo($value);
        } else {
            // Second problem
            // In this code block, we are sure both $gr & $value are objects
            // but we still use == comparison, instead of ===
            $matches = $gr == $value;
        }
    } else {
        $matches = $gr === $value;
    }
    $value = next($relocation['groups']);
}
if ($matches) {
    // ...
}
```

**TL;DR the only way to make the `Doctrine\Common\Comparable` work, is to return a boolean, not 0/1/-1**

---

The previous interface, `Gedmo\Sortable\Comparable` is undocumented, but from what I understand it was expecting a boolean, thus it was working. When the code was change to use `Doctrine\Common\Comparable`, it was supposed that both interfaces were the same, but they are not. Actually, we are looking for a [`isEquatable`](https://github.com/symfony/security-core/blob/030d56f6b70c4532ebdd8add29f54b8b8f10070f/User/EquatableInterface.php) interface.